### PR TITLE
fix: detect DuckDuckGo CAPTCHA and use browser-like User-Agent

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,6 +38,9 @@
 # The defaults below work well for most sites. Only change if you understand
 # what these settings do and have a specific reason to adjust them.
 
+# --- Browser Engine ---
+# SUPACRAWL_ENGINE=playwright  # playwright (default), patchright (stealth), camoufox (Akamai)
+
 # --- Browser Settings ---
 # SUPACRAWL_LOCALE=en-US
 # SUPACRAWL_TIMEZONE=Australia/Brisbane

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to calendar-based versioning (YYYY.MM.x format).
 
 ## [Unreleased]
 
+## [2026.3.0] - 2026-03-03
+
+### Features
+
+- **Camoufox anti-detection engine** (Closes #80): New `--engine camoufox` option provides Tier 3 anti-bot protection using patched Firefox. Effective against Akamai Bot Manager and advanced TLS fingerprinting. Install: `pip install supacrawl[camoufox]`
+- **Change tracking** (Closes #81): New `-f changeTracking` format detects content changes between scrapes by comparing against cached previous versions. Supports `--change-tracking-modes git-diff` for unified diffs
+- **PDF URL parsing** (Closes #82): Auto-detects `.pdf` URLs and extracts text directly, bypassing the browser. OCR fallback available via `pip install supacrawl[pdf-ocr]`. Controlled with `--parse-pdf [auto|fast|ocr|off]`
+- **Mobile device emulation** (Closes #83): New `--mobile` and `--device TEXT` flags for scraping as mobile devices using Playwright device descriptors. Use `--list-devices` to see available presets
+- **Iframe content extraction** (Closes #85): New `--expand-iframes [none|same-origin|all]` option (default: same-origin) expands iframe content inline during scraping
+- **JSON comparison mode for change tracking** (Closes #87): `--change-tracking-modes json` compares structured extracted fields between scrapes
+- **Change tracking in crawl** (Closes #88): `-f changeTracking` now works in the `crawl` command with `--change-tracking-modes` and `--cache-dir` support
+- **Per-request engine in MCP tools** (Closes #90): `engine` parameter on `supacrawl_scrape` and `supacrawl_crawl` MCP tools allows per-request engine selection. Server default configurable via `SUPACRAWL_ENGINE` environment variable
+
+### Fixed
+
+- **ERR_HTTP2_PROTOCOL_ERROR automatic fallback** (Closes #92): Two-stage auto-retry chain (Chromium to Camoufox to Camoufox + HTTP/1.1) handles servers that reject Chromium's TLS fingerprint
+- **Camoufox async wrapper** (Closes #91): Use correct `AsyncCamoufox` context manager instead of `AsyncNewBrowser`
+
+### Performance
+
+- **Reduced scrape overhead by ~1.7s per page** (Closes #89): Removed unnecessary PDF HEAD request from the scrape hot path
+
 ## [2026.2.3] - 2026-02-26
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ There are excellent web scraping tools available. Supacrawl takes a different ap
 - **MCP server**: Give AI assistants direct access to web scraping
 - **Clean markdown**: Playwright renders JS, outputs readable markdown
 - **LLM-ready**: Built-in extraction with Ollama, OpenAI, or Anthropic
-- **Stealth mode**: Patchright for anti-bot evasion, 2Captcha for CAPTCHAs
+- **Anti-bot protection**: Three-tier engine system (Playwright, Patchright, Camoufox) with automatic HTTP/2 fallback
+- **PDF parsing**: Auto-detect PDF URLs, extract text with optional OCR
+- **Mobile emulation**: Scrape as any mobile device using Playwright device descriptors
 
 ```bash
 pip install supacrawl
@@ -118,6 +120,7 @@ Pass environment variables via your MCP client config to customise behaviour:
       "command": "supacrawl-mcp",
       "args": ["--transport", "stdio"],
       "env": {
+        "SUPACRAWL_ENGINE": "camoufox",
         "SUPACRAWL_STEALTH": "true",
         "SUPACRAWL_LOCALE": "en-AU",
         "SUPACRAWL_TIMEZONE": "Australia/Sydney",
@@ -137,8 +140,9 @@ If scrapes return empty or minimal content, use `supacrawl_diagnose` to identify
 ### Optional Extras
 
 ```bash
-pip install supacrawl[mcp,stealth]   # Add anti-bot evasion
-pip install supacrawl[mcp,captcha]   # Add CAPTCHA solving
+pip install supacrawl[mcp,stealth]    # Patchright anti-bot evasion (Tier 2)
+pip install supacrawl[mcp,camoufox]   # Camoufox for Akamai/Cloudflare (Tier 3)
+pip install supacrawl[mcp,captcha]    # 2Captcha CAPTCHA solving
 ```
 
 ## Commands
@@ -173,11 +177,12 @@ Each markdown file includes YAML frontmatter with source URL and metadata.
 
 ### Core Settings
 
-| Variable             | Default | Description                |
-| -------------------- | ------- | -------------------------- |
-| `SUPACRAWL_HEADLESS` | `true`  | Set `false` to see browser |
-| `SUPACRAWL_TIMEOUT`  | `30000` | Page load timeout (ms)     |
-| `SUPACRAWL_PROXY`    | -       | Proxy URL (http/socks5)    |
+| Variable             | Default      | Description                                        |
+| -------------------- | ------------ | -------------------------------------------------- |
+| `SUPACRAWL_HEADLESS` | `true`       | Set `false` to see browser                         |
+| `SUPACRAWL_TIMEOUT`  | `30000`      | Page load timeout (ms)                             |
+| `SUPACRAWL_ENGINE`   | `playwright` | Browser engine: `playwright`, `patchright`, `camoufox` |
+| `SUPACRAWL_PROXY`    | -            | Proxy URL (http/socks5)                            |
 
 ### LLM Features
 
@@ -226,11 +231,13 @@ supacrawl cache clear   # Clear all cache (with confirmation)
 ### Optional Extras
 
 ```bash
-pip install supacrawl[stealth]   # Patchright for anti-bot evasion
-pip install supacrawl[captcha]   # 2Captcha for CAPTCHA solving
+pip install supacrawl[stealth]    # Patchright for anti-bot evasion (Tier 2)
+pip install supacrawl[camoufox]   # Camoufox for Akamai/Cloudflare bypass (Tier 3)
+pip install supacrawl[captcha]    # 2Captcha for CAPTCHA solving
+pip install supacrawl[pdf-ocr]    # OCR support for scanned PDFs
 ```
 
-Use `--stealth` and `--solve-captcha` flags when scraping protected sites. Stealth mode automatically runs headful (visible browser) for better anti-detection. CAPTCHA solving requires `CAPTCHA_API_KEY` environment variable.
+Select the browser engine with `--engine` (playwright, patchright, camoufox) or set `SUPACRAWL_ENGINE` as a default. Use `--stealth` for Tier 2, `--engine camoufox` for Tier 3, and `--solve-captcha` for CAPTCHA-protected sites. CAPTCHA solving requires `CAPTCHA_API_KEY` environment variable.
 
 Copy `.env.example` to `.env` to configure.
 
@@ -289,7 +296,8 @@ Supacrawl does one thing well: get clean markdown from the web.
 | **Web Search**           | Built-in (DuckDuckGo)     | Not included              | Via SearXNG                    | Yes               |
 | **LLM Providers**        | Ollama, OpenAI, Anthropic | Any via LiteLLM           | OpenAI (Ollama experimental)   | OpenAI            |
 | **Intelligent Crawling** | Yes (agent command)       | Yes (adaptive crawling)   | No                             | Yes (/agent)      |
-| **Stealth/Anti-bot**     | Yes (Patchright)          | Yes (undetected browser)  | No (Fire-engine is cloud-only) | Yes (Fire-engine) |
+| **Stealth/Anti-bot**     | Yes (3-tier: Patchright + Camoufox) | Yes (undetected browser) | No (Fire-engine is cloud-only) | Yes (Fire-engine) |
+| **PDF Parsing**          | Yes (text + OCR)          | No                        | No                             | No                |
 | **CAPTCHA Solving**      | Yes (2Captcha)            | Optional (CapSolver)      | No                             | No                |
 | **Caching**              | Local files               | Built-in                  | PostgreSQL                     | Managed           |
 | **Licence**              | MIT                       | Apache-2.0                | AGPL-3.0                       | AGPL-3.0          |

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ All [configuration](#configuration) environment variables apply. The MCP server 
 
 ### Troubleshooting
 
-If scrapes return empty or minimal content, use `supacrawl_diagnose` to identify the cause (CDN protection, JS framework, bot detection). Common fixes: increase `wait_for` for JS-heavy sites, enable `SUPACRAWL_STEALTH=true` for bot-protected sites, or try `only_main_content=false` if the wrong content is extracted.
+If scrapes return empty or minimal content, use `supacrawl_diagnose` to identify the cause (CDN protection, JS framework, bot detection). Common fixes: set `wait_for=3000` for JS-heavy sites (enables SPA stability polling), use `wait_until="load"` or `"networkidle"` if resources must fully load, enable `SUPACRAWL_STEALTH=true` for bot-protected sites, or try `only_main_content=false` if the wrong content is extracted.
 
 ### Optional Extras
 

--- a/docs/30-architecture/data-flow-llm.md
+++ b/docs/30-architecture/data-flow-llm.md
@@ -4,7 +4,9 @@
 
 **Primary method: Playwright + markdownify** (browser rendering + pattern-based extraction)
 
-This approach treats each page like an actual browser:
+PDF URLs are detected by file extension and parsed directly (text extraction with optional OCR), bypassing the browser entirely.
+
+For HTML pages, this approach treats each page like an actual browser:
 1. Playwright renders the page fully (JavaScript execution, SPA content loading)
 2. BeautifulSoup cleans the HTML (removes boilerplate)
 3. markdownify converts to markdown (preserves tables and structure)
@@ -59,8 +61,16 @@ This approach treats each page like an actual browser:
 │  ┌─────────────────────────────────────────────────────────────────┐   │
 │  │  Input: Single URL                                               │   │
 │  │                                                                   │   │
+│  │  Step 0: PDF Detection (when parse_pdf != "off")               │   │
+│  │    └── Check URL extension for .pdf                             │   │
+│  │    └── If PDF: extract text directly (skip browser)             │   │
+│  │    └── OCR fallback if text extraction yields nothing           │   │
+│  │                                                                   │   │
 │  │  Step 1: Fetch Page with Playwright                             │   │
+│  │    └── Select engine (playwright/patchright/camoufox)           │   │
+│  │    └── Apply device emulation if --mobile/--device set          │   │
 │  │    └── Render page (waits for domcontentloaded by default)      │   │
+│  │    └── Expand iframes (same-origin by default)                  │   │
 │  │    └── Optionally wait for SPA stability (when wait_for > 0)    │   │
 │  │    └── Returns: raw HTML (post-JavaScript)                      │   │
 │  │                                                                   │   │
@@ -218,3 +228,5 @@ User         CLI          CrawlService    MapService    ScrapeService    Convert
 2. **markdownify preserves structure** - Tables, links, and formatting stay intact
 3. **Pattern matching is reliable** - Framework-specific selectors work better than ML
 4. **Cost is $0** - All extraction runs locally, no API calls needed
+5. **PDF parsing bypasses the browser** - Direct text extraction is faster and more reliable than rendering PDFs in a browser
+6. **Engine selection matters for anti-bot** - Camoufox (Firefox-based) has a different TLS fingerprint than Chromium, which bypasses some bot detection

--- a/docs/30-architecture/data-flow-llm.md
+++ b/docs/30-architecture/data-flow-llm.md
@@ -60,11 +60,11 @@ This approach treats each page like an actual browser:
 │  │  Input: Single URL                                               │   │
 │  │                                                                   │   │
 │  │  Step 1: Fetch Page with Playwright                             │   │
-│  │    └── Render page fully (JavaScript execution)                 │   │
-│  │    └── Wait for SPA content to stabilize                        │   │
+│  │    └── Render page (waits for domcontentloaded by default)      │   │
+│  │    └── Optionally wait for SPA stability (when wait_for > 0)    │   │
 │  │    └── Returns: raw HTML (post-JavaScript)                      │   │
 │  │                                                                   │   │
-│  │  Step 2: Extract Metadata                                        │   │
+│  │  Step 2: Extract Metadata (from <head> section)                  │   │
 │  │    └── Parse <title>, <meta>, OpenGraph tags                    │   │
 │  │                                                                   │   │
 │  │  Step 3: Convert to Markdown                                     │   │

--- a/docs/40-usage/cli-usage-supacrawl.md
+++ b/docs/40-usage/cli-usage-supacrawl.md
@@ -48,9 +48,16 @@ supacrawl scrape URL [OPTIONS]
 - `--max-age INT` - Cache freshness in seconds (0=no cache, default: 0)
 - `--cache-dir PATH` - Cache directory (default: `~/.supacrawl/cache`)
 - `--stealth/--no-stealth` - Enhanced stealth mode via Patchright (requires: `pip install supacrawl[stealth]`)
+- `--engine CHOICE` - Browser engine: `playwright` (default), `patchright` (Tier 2 stealth, requires `supacrawl[stealth]`), `camoufox` (Tier 3 for Akamai/Cloudflare, requires `supacrawl[camoufox]`). Overrides `--stealth`. Also reads `SUPACRAWL_ENGINE` env
 - `--proxy URL` - Proxy URL (e.g., `http://user:pass@host:port`, `socks5://host:port`)
 - `--solve-captcha/--no-solve-captcha` - Enable CAPTCHA solving via 2Captcha (requires: `pip install supacrawl[captcha]` and `CAPTCHA_API_KEY`)
 - `--wait-until STRATEGY` - Page load strategy: `commit`, `domcontentloaded`, `load`, `networkidle` (default: domcontentloaded)
+- `--change-tracking-modes CHOICE` - Diff modes for change tracking: `git-diff`, `json` (can specify multiple). Requires `-f changeTracking`
+- `--expand-iframes CHOICE` - Iframe content expansion: `none` (strip all), `same-origin` (default, expand same-origin inline), `all` (expand all non-blocked)
+- `--mobile/--no-mobile` - Scrape as a default mobile device (iPhone 14). Sets mobile viewport, user agent, and touch support
+- `--device TEXT` - Emulate a specific device (e.g. "iPhone 15", "Pixel 7"). Overrides `--mobile`. See `--list-devices` for available presets
+- `--list-devices` - List all available device presets and exit
+- `--parse-pdf CHOICE` - PDF URL parsing mode: `auto` (default, detect .pdf URLs and extract text with OCR fallback), `fast` (text extraction only), `ocr` (force OCR, requires `supacrawl[pdf-ocr]`), `off` (disable, render in browser)
 
 **Example:**
 ```bash
@@ -89,6 +96,36 @@ $ supacrawl scrape https://protected-site.com --stealth
 
 $ supacrawl scrape https://captcha-site.com --stealth --solve-captcha
 # Solve CAPTCHAs automatically (costs ~$0.002-0.003 each)
+
+$ supacrawl scrape https://akamai-site.com --engine camoufox
+# Use Camoufox engine for Akamai-protected sites
+
+$ supacrawl scrape https://example.com --mobile
+# Scrape as default mobile device (iPhone 14)
+
+$ supacrawl scrape https://example.com --device "iPhone 15"
+# Emulate a specific device
+
+$ supacrawl scrape https://example.com --mobile -f screenshot -o mobile.png
+# Capture mobile screenshot
+
+$ supacrawl scrape --list-devices
+# Show all available device presets
+
+$ supacrawl scrape https://example.com/report.pdf
+# Auto-detect PDF URL and extract text
+
+$ supacrawl scrape https://example.com/scanned.pdf --parse-pdf ocr
+# Force OCR for scanned PDF (requires supacrawl[pdf-ocr])
+
+$ supacrawl scrape https://example.com -f changeTracking --max-age 3600
+# Track content changes (compares against cached previous scrape)
+
+$ supacrawl scrape https://example.com -f changeTracking --change-tracking-modes git-diff
+# Get unified diff of changes
+
+$ supacrawl scrape https://example.com --expand-iframes all
+# Include content from all iframes
 ```
 
 ### crawl
@@ -110,16 +147,20 @@ supacrawl crawl URL [OPTIONS]
 - `--exclude TEXT` - URL patterns to exclude (glob patterns, can specify multiple)
 - `-o, --output DIRECTORY` - Output directory for scraped content (required)
 - `--resume` - Resume from previous crawl
-- `-f, --format FORMAT` - Output format: `markdown`, `html`, or `json` (default: `markdown`, can specify multiple)
+- `-f, --format FORMAT` - Output format: `markdown`, `html`, `json`, `changeTracking` (default: `markdown`, can specify multiple)
 - `--deduplicate-similar-urls` - Deduplicate URLs that differ only by tracking parameters or fragments
 - `--allow-external-links` - Follow and scrape links to external domains
 - `--country CODE` - ISO country code for locale settings (e.g., AU, US, DE)
 - `--language CODE` - Browser language/locale code (e.g., en-AU, de-DE)
 - `--timezone TZ` - IANA timezone (e.g., Australia/Sydney)
 - `--stealth/--no-stealth` - Enhanced stealth mode via Patchright
+- `--engine CHOICE` - Browser engine: `playwright` (default), `patchright`, `camoufox`. See scrape command for details
 - `--proxy URL` - Proxy URL (e.g., `http://user:pass@host:port`)
 - `-c, --concurrency INT` - Max concurrent requests (default: 10)
 - `--wait-until STRATEGY` - Page load strategy: `commit`, `domcontentloaded`, `load`, `networkidle`
+- `--cache-dir PATH` - Cache directory for change tracking (default: `~/.supacrawl/cache`)
+- `--change-tracking-modes CHOICE` - Diff modes for change tracking: `git-diff`, `json` (can specify multiple). Requires `-f changeTracking`
+- `--expand-iframes CHOICE` - Iframe content expansion: `none`, `same-origin` (default), `all`
 
 **Example:**
 ```bash
@@ -137,6 +178,12 @@ $ supacrawl crawl https://example.com -o ./output --deduplicate-similar-urls
 
 $ supacrawl crawl https://example.com -o ./output --country AU
 # Set browser locale to Australia
+
+$ supacrawl crawl https://example.com -o ./output -f changeTracking --change-tracking-modes git-diff
+# Track content changes across all crawled pages
+
+$ supacrawl crawl https://example.com -o ./output --engine camoufox
+# Crawl using Camoufox engine for protected sites
 ```
 
 ### map
@@ -381,16 +428,32 @@ EOF
 supacrawl scrape https://spa.example.com --actions actions.json
 ```
 
-### Bot-Protected Sites
+### Anti-Bot Protection
 
-When sites block automated access, use stealth mode and CAPTCHA solving.
+Supacrawl uses a three-tier engine system for anti-bot protection:
+
+| Tier | Engine | Install | Use Case |
+|------|--------|---------|----------|
+| 1 | Playwright (default) | Included | Basic stealth scripts, always active |
+| 2 | Patchright | `pip install supacrawl[stealth]` | Cloudflare, general anti-bot |
+| 3 | Camoufox | `pip install supacrawl[camoufox]` | Akamai Bot Manager, advanced TLS fingerprinting |
+
+Select the engine explicitly or let supacrawl auto-detect:
 
 ```bash
-# Install stealth extras
-pip install supacrawl[stealth]
+# Tier 1: Basic stealth (always active, no flags needed)
+supacrawl scrape https://example.com
 
-# Scrape with stealth mode
-supacrawl scrape https://protected.example.com --stealth
+# Tier 2: Patchright for Cloudflare-protected sites
+supacrawl scrape https://protected-site.com --stealth
+supacrawl scrape https://protected-site.com --engine patchright
+
+# Tier 3: Camoufox for Akamai-protected sites
+supacrawl scrape https://akamai-site.com --engine camoufox
+
+# Set default engine via environment variable
+export SUPACRAWL_ENGINE=camoufox
+supacrawl scrape https://akamai-site.com
 
 # Debug with visible browser
 SUPACRAWL_HEADLESS=false supacrawl scrape https://protected.example.com --stealth
@@ -399,12 +462,80 @@ SUPACRAWL_HEADLESS=false supacrawl scrape https://protected.example.com --stealt
 supacrawl scrape https://protected.example.com -f screenshot -o debug.png
 ```
 
+If a Chromium-based engine encounters an HTTP/2 protocol error, supacrawl automatically retries with Camoufox (if installed). This two-stage fallback handles servers that reject Chromium's TLS fingerprint.
+
 For CAPTCHA-protected sites:
 
 ```bash
 pip install supacrawl[captcha]
 export CAPTCHA_API_KEY=your-2captcha-api-key
 supacrawl scrape https://captcha-site.example.com --stealth --solve-captcha
+```
+
+### Change Tracking
+
+Track content changes between scrapes using the cache. Requires a previous cached scrape to compare against.
+
+```bash
+# First scrape (populates cache)
+supacrawl scrape https://example.com --max-age 3600
+
+# Later: detect changes
+supacrawl scrape https://example.com -f changeTracking --max-age 3600
+
+# Get a unified diff of changes
+supacrawl scrape https://example.com -f changeTracking --change-tracking-modes git-diff
+
+# JSON comparison mode (requires --prompt or --schema for structured extraction)
+supacrawl scrape https://example.com -f changeTracking --change-tracking-modes json \
+  --prompt "Extract product prices"
+
+# Track changes across an entire site
+supacrawl crawl https://example.com -o ./output -f changeTracking \
+  --change-tracking-modes git-diff --cache-dir ~/.supacrawl/cache
+```
+
+Change tracking returns a status (`new`, `same`, or `changed`) and optionally a diff. The `git-diff` mode produces unified diffs; the `json` mode compares structured extracted fields.
+
+### PDF Parsing
+
+Supacrawl auto-detects PDF URLs (by `.pdf` extension) and extracts text directly, bypassing the browser entirely.
+
+```bash
+# Auto-detect and extract text (default behaviour)
+supacrawl scrape https://example.com/report.pdf
+
+# Text extraction only (no OCR fallback)
+supacrawl scrape https://example.com/report.pdf --parse-pdf fast
+
+# Force OCR for scanned documents
+pip install supacrawl[pdf-ocr]
+supacrawl scrape https://example.com/scanned.pdf --parse-pdf ocr
+
+# Extract structured data from PDF
+supacrawl scrape https://example.com/report.pdf -f json --prompt "Extract revenue figures"
+
+# Disable PDF parsing (render in browser)
+supacrawl scrape https://example.com/report.pdf --parse-pdf off
+```
+
+### Mobile Emulation
+
+Scrape pages as a mobile device using Playwright's device descriptors. This sets the viewport, user agent, device scale factor, and touch support.
+
+```bash
+# Scrape as default mobile device (iPhone 14)
+supacrawl scrape https://example.com --mobile
+
+# Emulate a specific device
+supacrawl scrape https://example.com --device "iPhone 15"
+supacrawl scrape https://example.com --device "Pixel 7"
+
+# Capture mobile screenshot
+supacrawl scrape https://example.com --mobile -f screenshot -o mobile.png
+
+# List all available device presets
+supacrawl scrape --list-devices
 ```
 
 ### Extracting Structured Data
@@ -471,6 +602,7 @@ supacrawl scrape https://example.com --language en-AU --timezone Australia/Sydne
 - `SUPACRAWL_HEADLESS` - Run headless (default: `true`)
 - `SUPACRAWL_TIMEOUT` - Page load timeout in ms (default: `30000`)
 - `SUPACRAWL_WAIT_UNTIL` - Default page load strategy (`commit`, `domcontentloaded`, `load`, `networkidle`; default: `domcontentloaded`)
+- `SUPACRAWL_ENGINE` - Default browser engine: `playwright`, `patchright`, `camoufox` (overridden by `--engine`)
 - `SUPACRAWL_PROXY` - Proxy URL (http/socks5)
 - `SUPACRAWL_CACHE_DIR` - Cache directory (default: `~/.supacrawl/cache`)
 
@@ -518,9 +650,12 @@ All errors include correlation IDs for debugging:
 - Run `playwright install chromium` to verify Playwright browsers are installed
 - For 4xx client errors, fix cookies/auth/proxy; retries are skipped by design
 - For rate limits, use `--wait-for` to add delays between requests or reduce crawl `--limit`
-- Use `--stealth` for bot-protected sites (requires `pip install supacrawl[stealth]`)
+- Use `--stealth` or `--engine patchright` for bot-protected sites (requires `pip install supacrawl[stealth]`)
+- Use `--engine camoufox` for Akamai-protected sites (requires `pip install supacrawl[camoufox]`)
+- HTTP/2 protocol errors are automatically retried with Camoufox if installed
 - Use `--solve-captcha` for CAPTCHA-protected sites (requires `pip install supacrawl[captcha]` and `CAPTCHA_API_KEY`)
 - Set `SUPACRAWL_HEADLESS=false` to see what the browser sees during debugging
+- For PDF URLs returning empty content, check `--parse-pdf` mode (default `auto` detects `.pdf` extensions)
 
 ## Best Practices
 

--- a/docs/40-usage/cli-usage-supacrawl.md
+++ b/docs/40-usage/cli-usage-supacrawl.md
@@ -50,7 +50,7 @@ supacrawl scrape URL [OPTIONS]
 - `--stealth/--no-stealth` - Enhanced stealth mode via Patchright (requires: `pip install supacrawl[stealth]`)
 - `--proxy URL` - Proxy URL (e.g., `http://user:pass@host:port`, `socks5://host:port`)
 - `--solve-captcha/--no-solve-captcha` - Enable CAPTCHA solving via 2Captcha (requires: `pip install supacrawl[captcha]` and `CAPTCHA_API_KEY`)
-- `--wait-until STRATEGY` - Page load strategy: `commit`, `domcontentloaded`, `load`, `networkidle` (default: load)
+- `--wait-until STRATEGY` - Page load strategy: `commit`, `domcontentloaded`, `load`, `networkidle` (default: domcontentloaded)
 
 **Example:**
 ```bash
@@ -353,13 +353,16 @@ supacrawl crawl https://docs.example.com -o ./docs \
 
 ### Handling JS-Heavy SPAs
 
-Single-page applications load content dynamically. Use wait strategies to ensure content is rendered.
+Single-page applications load content dynamically. The default `domcontentloaded` strategy waits for the initial DOM but not for async JavaScript. Use wait strategies to ensure SPA content is rendered:
 
 ```bash
 # Wait until all network requests complete
 supacrawl scrape https://spa.example.com --wait-until networkidle
 
-# Add extra wait time for slow JavaScript
+# Enable SPA stability polling (waits for DOM to stop changing)
+supacrawl scrape https://spa.example.com --wait-for 3000
+
+# Both: wait for network idle, then poll for DOM stability
 supacrawl scrape https://spa.example.com --wait-until networkidle --wait-for 3000
 ```
 
@@ -467,7 +470,7 @@ supacrawl scrape https://example.com --language en-AU --timezone Australia/Sydne
 
 - `SUPACRAWL_HEADLESS` - Run headless (default: `true`)
 - `SUPACRAWL_TIMEOUT` - Page load timeout in ms (default: `30000`)
-- `SUPACRAWL_WAIT_UNTIL` - Default page load strategy (`commit`, `domcontentloaded`, `load`, `networkidle`)
+- `SUPACRAWL_WAIT_UNTIL` - Default page load strategy (`commit`, `domcontentloaded`, `load`, `networkidle`; default: `domcontentloaded`)
 - `SUPACRAWL_PROXY` - Proxy URL (http/socks5)
 - `SUPACRAWL_CACHE_DIR` - Cache directory (default: `~/.supacrawl/cache`)
 

--- a/docs/70-reliability/error-handling-supacrawl.md
+++ b/docs/70-reliability/error-handling-supacrawl.md
@@ -145,6 +145,33 @@ raise ProviderError(...) from e
 
 This preserves the exception chain for debugging while showing user-friendly messages.
 
+## Automatic Error Recovery
+
+### HTTP/2 Protocol Error Fallback
+
+When a Chromium-based engine (Playwright or Patchright) encounters an `ERR_HTTP2_PROTOCOL_ERROR`, supacrawl automatically retries with Camoufox if it is installed. This handles servers that reject Chromium's TLS fingerprint (common with Akamai Bot Manager).
+
+The fallback is a two-stage chain:
+
+1. **Chromium fails** -> retry with Camoufox (different TLS fingerprint via Firefox)
+2. **Camoufox with HTTP/2 fails** -> retry with Camoufox + HTTP/1.1 forced (disables HTTP/2 via Firefox preferences)
+
+This fallback is transparent to the user. If Camoufox is not installed, the error is raised with a hint to install it.
+
+### Bot Detection Auto-Retry
+
+When basic Playwright scraping returns what appears to be a bot-detection page (based on status code and content heuristics), supacrawl automatically retries with Patchright stealth mode if available.
+
+The full retry chain for a scrape request:
+
+```
+Playwright (Tier 1) -> bot detected? -> Patchright (Tier 2)
+                    -> HTTP/2 error?  -> Camoufox (Tier 3)
+                                      -> HTTP/2 error? -> Camoufox + HTTP/1.1
+```
+
+Each stage only triggers if the required package is installed (`supacrawl[stealth]` for Patchright, `supacrawl[camoufox]` for Camoufox).
+
 ## Validation Error Patterns
 
 ### Field Validation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
   "httpx>=0.28.1",
   "markdownify>=1.2.2",
   "ollama>=0.1.0",
+  "pdfplumber>=0.11.0",
   "playwright>=1.40.0,<2.0.0",
   "pydantic>=2.9.0",
   "pyyaml>=6.0.1",
@@ -58,6 +59,10 @@ camoufox = [
 ]
 captcha = [
   "2captcha-python>=2.0.2",
+]
+pdf-ocr = [
+  "pytesseract>=0.3.10",
+  "pdf2image>=1.16.0",
 ]
 mcp = [
   "anyio>=4.0.0",
@@ -114,6 +119,18 @@ ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
 module = "camoufox.*"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "pdfplumber.*"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "pytesseract.*"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "pdf2image.*"
 ignore_missing_imports = true
 
 [tool.hatch.build.targets.sdist]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,9 @@ dev = [
 stealth = [
   "patchright>=1.56.0",
 ]
+camoufox = [
+  "camoufox[geoip]>=0.4.0",
+]
 captcha = [
   "2captcha-python>=2.0.2",
 ]
@@ -107,6 +110,10 @@ python_version = "3.12"
 
 [[tool.mypy.overrides]]
 module = "twocaptcha.*"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "camoufox.*"
 ignore_missing_imports = true
 
 [tool.hatch.build.targets.sdist]

--- a/src/supacrawl/cache.py
+++ b/src/supacrawl/cache.py
@@ -23,6 +23,7 @@ class CacheEntry(BaseModel):
     url: str
     cached_at: str  # ISO format timestamp
     expires_at: str  # ISO format timestamp
+    content_hash: str | None = None  # SHA256 of markdown content for change tracking
     response: dict[str, Any]  # Serialised ScrapeResult
 
 
@@ -199,7 +200,39 @@ class CacheManager:
             LOGGER.warning(f"Failed to read cache entry for {url}: {e}")
             return None
 
-    def set(self, url: str, response: dict[str, Any], max_age: int, variant: str | None = None) -> None:
+    def get_previous(self, url: str, variant: str | None = None) -> CacheEntry | None:
+        """Get previous cached entry regardless of expiry (for change tracking).
+
+        Unlike :meth:`get`, this ignores expiry and returns the raw CacheEntry
+        so callers can access ``content_hash`` and ``cached_at`` for comparison.
+
+        Args:
+            url: URL to look up.
+            variant: Optional variant suffix (must match the value used in :meth:`set`).
+
+        Returns:
+            CacheEntry if found, None if no cached entry exists.
+        """
+        cache_key = self._cache_key(url, variant=variant)
+        cache_file = self.pages_dir / f"{cache_key}.json"
+
+        if not cache_file.exists():
+            return None
+
+        try:
+            return CacheEntry.model_validate_json(cache_file.read_text())
+        except Exception as e:
+            LOGGER.warning(f"Failed to read cache entry for {url}: {e}")
+            return None
+
+    def set(
+        self,
+        url: str,
+        response: dict[str, Any],
+        max_age: int,
+        variant: str | None = None,
+        content_hash: str | None = None,
+    ) -> None:
         """Cache a scrape result.
 
         Args:
@@ -208,6 +241,7 @@ class CacheManager:
             max_age: Time-to-live in seconds.
             variant: Optional variant suffix to differentiate cache entries
                 for the same URL with different request parameters.
+            content_hash: SHA256 hash of markdown content for change tracking.
         """
         if max_age <= 0:
             return
@@ -222,6 +256,7 @@ class CacheManager:
             url=url,
             cached_at=now.isoformat(),
             expires_at=expires_at.isoformat(),
+            content_hash=content_hash,
             response=response,
         )
 

--- a/src/supacrawl/cli/crawl.py
+++ b/src/supacrawl/cli/crawl.py
@@ -109,7 +109,7 @@ from supacrawl.cli._common import app
     "--wait-until",
     type=click.Choice(["commit", "domcontentloaded", "load", "networkidle"], case_sensitive=False),
     default=None,
-    help="Page load strategy. Default: load. Use 'networkidle' for JS-heavy sites. Also reads SUPACRAWL_WAIT_UNTIL env.",
+    help="Page load strategy. Default: domcontentloaded. Use 'load' to wait for all resources, 'networkidle' for JS-heavy sites. Also reads SUPACRAWL_WAIT_UNTIL env.",
 )
 @click.option(
     "--engine",

--- a/src/supacrawl/cli/crawl.py
+++ b/src/supacrawl/cli/crawl.py
@@ -51,7 +51,7 @@ from supacrawl.cli._common import app
     "-f",
     "formats",
     multiple=True,
-    type=click.Choice(["markdown", "html", "json"], case_sensitive=False),
+    type=click.Choice(["markdown", "html", "json", "changeTracking"], case_sensitive=False),
     default=["markdown"],
     show_default=True,
     help="Output formats to save",
@@ -117,6 +117,18 @@ from supacrawl.cli._common import app
     default=None,
     help="Browser engine. playwright=default, patchright=Tier 2 stealth (requires supacrawl[stealth]), camoufox=Tier 3 for Akamai (requires supacrawl[camoufox]). Overrides --stealth.",
 )
+@click.option(
+    "--cache-dir",
+    type=click.Path(file_okay=False, dir_okay=True, path_type=Path),
+    default=None,
+    help="Cache directory for change tracking. Defaults to ~/.supacrawl/cache or SUPACRAWL_CACHE_DIR.",
+)
+@click.option(
+    "--change-tracking-modes",
+    multiple=True,
+    type=click.Choice(["git-diff", "json"], case_sensitive=False),
+    help="Diff modes for change tracking. Requires -f changeTracking. Options: git-diff, json.",
+)
 def crawl_cmd(
     url: str,
     limit: int,
@@ -136,6 +148,8 @@ def crawl_cmd(
     concurrency: int,
     wait_until: str | None,
     engine: str | None,
+    cache_dir: Path | None,
+    change_tracking_modes: tuple[str, ...],
 ) -> None:
     """Crawl a website and save all pages.
 
@@ -146,6 +160,7 @@ def crawl_cmd(
         supacrawl crawl https://example.com --output corpus/ --deduplicate-similar-urls
         supacrawl crawl https://example.com --output corpus/ --allow-external-links --limit 50
         supacrawl crawl https://example.com --output corpus/ --country AU
+        supacrawl crawl https://example.com --output corpus/ -f changeTracking --change-tracking-modes git-diff
     """
     import asyncio
 
@@ -166,6 +181,14 @@ def crawl_cmd(
         else:
             locale_config = LocaleConfig(language=language, timezone=timezone)
 
+    # Resolve cache directory if change tracking is requested
+    formats_list = list(formats)
+    resolved_cache_dir = cache_dir
+    if "changeTracking" in formats_list and not resolved_cache_dir:
+        from supacrawl.cache import CacheManager
+
+        resolved_cache_dir = CacheManager.DEFAULT_CACHE_DIR
+
     async def run():
         from urllib.parse import urlparse
 
@@ -181,7 +204,7 @@ def crawl_cmd(
             exclude_patterns=list(exclude) if exclude else None,
             output_dir=output,
             resume=resume,
-            formats=list(formats),
+            formats=formats_list,
             deduplicate_similar_urls=deduplicate_similar_urls,
             allow_external_links=allow_external_links,
             locale_config=locale_config,
@@ -190,6 +213,8 @@ def crawl_cmd(
             concurrency=concurrency,
             wait_until=wait_until,  # type: ignore[arg-type]
             engine=engine,
+            cache_dir=resolved_cache_dir,
+            change_tracking_modes=list(change_tracking_modes) if change_tracking_modes else None,
         ):
             if event.type == "progress":
                 # Show progress bar
@@ -217,5 +242,8 @@ def crawl_cmd(
                     click.echo(f"\n  x {path} ({error_msg})", err=True)
             elif event.type == "complete":
                 click.echo(f"\n\nComplete: {event.completed}/{event.total} pages", err=True)
+                if event.change_summary:
+                    parts = [f"{v} {k}" for k, v in event.change_summary.items()]
+                    click.echo(f"Changes: {', '.join(parts)}", err=True)
 
     asyncio.run(run())

--- a/src/supacrawl/cli/crawl.py
+++ b/src/supacrawl/cli/crawl.py
@@ -111,6 +111,12 @@ from supacrawl.cli._common import app
     default=None,
     help="Page load strategy. Default: load. Use 'networkidle' for JS-heavy sites. Also reads SUPACRAWL_WAIT_UNTIL env.",
 )
+@click.option(
+    "--engine",
+    type=click.Choice(["playwright", "patchright", "camoufox"], case_sensitive=False),
+    default=None,
+    help="Browser engine. playwright=default, patchright=Tier 2 stealth (requires supacrawl[stealth]), camoufox=Tier 3 for Akamai (requires supacrawl[camoufox]). Overrides --stealth.",
+)
 def crawl_cmd(
     url: str,
     limit: int,
@@ -129,6 +135,7 @@ def crawl_cmd(
     proxy: str | None,
     concurrency: int,
     wait_until: str | None,
+    engine: str | None,
 ) -> None:
     """Crawl a website and save all pages.
 
@@ -182,6 +189,7 @@ def crawl_cmd(
             proxy=proxy,
             concurrency=concurrency,
             wait_until=wait_until,  # type: ignore[arg-type]
+            engine=engine,
         ):
             if event.type == "progress":
                 # Show progress bar

--- a/src/supacrawl/cli/crawl.py
+++ b/src/supacrawl/cli/crawl.py
@@ -129,6 +129,13 @@ from supacrawl.cli._common import app
     type=click.Choice(["git-diff", "json"], case_sensitive=False),
     help="Diff modes for change tracking. Requires -f changeTracking. Options: git-diff, json.",
 )
+@click.option(
+    "--expand-iframes",
+    type=click.Choice(["none", "same-origin", "all"], case_sensitive=False),
+    default="same-origin",
+    show_default=True,
+    help="Iframe expansion mode. none=strip all, same-origin=expand same-origin inline, all=expand all non-blocked.",
+)
 def crawl_cmd(
     url: str,
     limit: int,
@@ -150,6 +157,7 @@ def crawl_cmd(
     engine: str | None,
     cache_dir: Path | None,
     change_tracking_modes: tuple[str, ...],
+    expand_iframes: str,
 ) -> None:
     """Crawl a website and save all pages.
 
@@ -215,6 +223,7 @@ def crawl_cmd(
             engine=engine,
             cache_dir=resolved_cache_dir,
             change_tracking_modes=list(change_tracking_modes) if change_tracking_modes else None,
+            expand_iframes=expand_iframes,
         ):
             if event.type == "progress":
                 # Show progress bar

--- a/src/supacrawl/cli/map.py
+++ b/src/supacrawl/cli/map.py
@@ -89,6 +89,12 @@ from supacrawl.cli._common import app
     help="Page load strategy. Default: load. Use 'networkidle' for JS-heavy sites. Also reads SUPACRAWL_WAIT_UNTIL env.",
 )
 @click.option(
+    "--engine",
+    type=click.Choice(["playwright", "patchright", "camoufox"], case_sensitive=False),
+    default=None,
+    help="Browser engine. playwright=default, patchright=Tier 2 stealth (requires supacrawl[stealth]), camoufox=Tier 3 for Akamai (requires supacrawl[camoufox]). Overrides --stealth.",
+)
+@click.option(
     "--ignore-cache",
     is_flag=True,
     default=False,
@@ -108,6 +114,7 @@ def map_cmd(
     proxy: str | None,
     concurrency: int,
     wait_until: str | None,
+    engine: str | None,
     ignore_cache: bool,
 ) -> None:
     """Map a website to discover all URLs.
@@ -129,6 +136,7 @@ def map_cmd(
             proxy=proxy,
             concurrency=concurrency,
             wait_until=wait_until,  # type: ignore[arg-type]
+            engine=engine,
         )
         result = None
         last_progress = ""

--- a/src/supacrawl/cli/scrape.py
+++ b/src/supacrawl/cli/scrape.py
@@ -155,7 +155,7 @@ from supacrawl.models import DEFAULT_MOBILE_DEVICE
     "--wait-until",
     type=click.Choice(["commit", "domcontentloaded", "load", "networkidle"], case_sensitive=False),
     default=None,
-    help="Page load strategy. Default: load. Use 'networkidle' for JS-heavy sites. Also reads SUPACRAWL_WAIT_UNTIL env.",
+    help="Page load strategy. Default: domcontentloaded. Use 'load' to wait for all resources, 'networkidle' for JS-heavy sites. Also reads SUPACRAWL_WAIT_UNTIL env.",
 )
 @click.option(
     "--change-tracking-modes",

--- a/src/supacrawl/cli/scrape.py
+++ b/src/supacrawl/cli/scrape.py
@@ -15,7 +15,19 @@ from supacrawl.cli._common import app
     "formats",
     multiple=True,
     type=click.Choice(
-        ["markdown", "html", "rawHtml", "links", "images", "screenshot", "pdf", "json", "branding", "summary"],
+        [
+            "markdown",
+            "html",
+            "rawHtml",
+            "links",
+            "images",
+            "screenshot",
+            "pdf",
+            "json",
+            "branding",
+            "summary",
+            "changeTracking",
+        ],
         case_sensitive=False,
     ),
     default=["markdown"],
@@ -144,6 +156,12 @@ from supacrawl.cli._common import app
     default=None,
     help="Page load strategy. Default: load. Use 'networkidle' for JS-heavy sites. Also reads SUPACRAWL_WAIT_UNTIL env.",
 )
+@click.option(
+    "--change-tracking-modes",
+    multiple=True,
+    type=click.Choice(["git-diff"], case_sensitive=False),
+    help="Diff modes for change tracking. Requires -f changeTracking. Options: git-diff.",
+)
 def scrape_url(
     url: str,
     formats: tuple[str, ...],
@@ -167,6 +185,7 @@ def scrape_url(
     proxy: str | None,
     solve_captcha: bool,
     wait_until: str | None,
+    change_tracking_modes: tuple[str, ...],
 ) -> None:
     """Scrape a single URL and extract content.
 
@@ -272,10 +291,11 @@ def scrape_url(
         else:
             locale_config = LocaleConfig(language=language, timezone=timezone)
 
-    # Resolve cache directory if max_age is set
-    resolved_cache_dir = cache_dir if max_age > 0 else None
-    if max_age > 0 and not resolved_cache_dir:
-        # Use default cache dir when max_age is set but no explicit cache_dir
+    # Resolve cache directory if max_age is set or change tracking is requested
+    # Change tracking needs a cache to store/compare previous versions
+    needs_cache = max_age > 0 or "changeTracking" in formats_list
+    resolved_cache_dir = cache_dir if needs_cache else None
+    if needs_cache and not resolved_cache_dir:
         from supacrawl.cache import CacheManager
 
         resolved_cache_dir = CacheManager.DEFAULT_CACHE_DIR
@@ -310,6 +330,7 @@ def scrape_url(
             exclude_tags=list(exclude_tags) if exclude_tags else None,
             max_age=max_age,
             wait_until=wait_until,  # type: ignore[arg-type]
+            change_tracking_modes=list(change_tracking_modes) if change_tracking_modes else None,
         )
         return result
 

--- a/src/supacrawl/cli/scrape.py
+++ b/src/supacrawl/cli/scrape.py
@@ -122,6 +122,12 @@ from supacrawl.cli._common import app
     help="Enhanced stealth mode via Patchright (requires: pip install supacrawl[stealth]). Note: Basic anti-bot evasion is always active.",
 )
 @click.option(
+    "--engine",
+    type=click.Choice(["playwright", "patchright", "camoufox"], case_sensitive=False),
+    default=None,
+    help="Browser engine. playwright=default, patchright=Tier 2 stealth (requires supacrawl[stealth]), camoufox=Tier 3 for Akamai (requires supacrawl[camoufox]). Overrides --stealth.",
+)
+@click.option(
     "--proxy",
     type=str,
     default=None,
@@ -157,6 +163,7 @@ def scrape_url(
     max_age: int,
     cache_dir: Path | None,
     stealth: bool,
+    engine: str | None,
     proxy: str | None,
     solve_captcha: bool,
     wait_until: str | None,
@@ -208,7 +215,8 @@ def scrape_url(
         supacrawl scrape https://example.com --language en-AU --timezone Australia/Sydney
         supacrawl scrape https://example.com --max-age 3600  # Use cache if fresh within 1 hour
         supacrawl scrape https://example.com --max-age 3600 --cache-dir ~/.my-cache
-        supacrawl scrape https://protected-site.com --stealth  # Force stealth mode
+        supacrawl scrape https://protected-site.com --stealth  # Force stealth mode (Patchright)
+        supacrawl scrape https://akamai-site.com --engine camoufox  # Tier 3: Akamai bypass
         supacrawl scrape https://captcha-site.com --stealth --solve-captcha  # Solve CAPTCHAs
         supacrawl scrape https://spa-site.com --wait-until networkidle  # Wait for JS to finish
     """
@@ -286,6 +294,7 @@ def scrape_url(
             stealth=stealth,
             proxy=proxy,
             solve_captcha=solve_captcha,
+            engine=engine,
         )
         result = await service.scrape(
             url=url,

--- a/src/supacrawl/cli/scrape.py
+++ b/src/supacrawl/cli/scrape.py
@@ -187,6 +187,13 @@ from supacrawl.models import DEFAULT_MOBILE_DEVICE
     default=False,
     help="List available device presets and exit.",
 )
+@click.option(
+    "--parse-pdf",
+    type=click.Choice(["fast", "auto", "ocr", "off"], case_sensitive=False),
+    default="auto",
+    show_default=True,
+    help="PDF parsing mode. auto=detect PDFs and extract text (OCR fallback if available), fast=text only, ocr=force OCR, off=disable.",
+)
 def scrape_url(
     url: str | None,
     formats: tuple[str, ...],
@@ -215,6 +222,7 @@ def scrape_url(
     mobile: bool,
     device: str | None,
     list_devices: bool,
+    parse_pdf: str,
 ) -> None:
     """Scrape a single URL and extract content.
 
@@ -271,6 +279,11 @@ def scrape_url(
         supacrawl scrape https://example.com --device "iPhone 15"  # Scrape as iPhone 15
         supacrawl scrape https://example.com --mobile -f screenshot -o mobile.png  # Mobile screenshot
         supacrawl scrape --list-devices  # Show available device presets
+        supacrawl scrape https://example.com/report.pdf  # Auto-detect PDF and extract text
+        supacrawl scrape https://example.com/report.pdf --parse-pdf fast  # Text extraction only
+        supacrawl scrape https://example.com/scanned.pdf --parse-pdf ocr  # Force OCR
+        supacrawl scrape https://example.com/report.pdf -f json --prompt "Extract revenue figures"
+        supacrawl scrape https://example.com/report.pdf --parse-pdf off  # Disable PDF parsing
     """
     import asyncio
     import base64
@@ -393,6 +406,7 @@ def scrape_url(
             change_tracking_modes=list(change_tracking_modes) if change_tracking_modes else None,
             expand_iframes=expand_iframes,  # type: ignore[arg-type]
             device=resolved_device,
+            parse_pdf=parse_pdf if parse_pdf != "off" else None,  # type: ignore[arg-type]
         )
         return result
 

--- a/src/supacrawl/cli/scrape.py
+++ b/src/supacrawl/cli/scrape.py
@@ -192,7 +192,7 @@ from supacrawl.models import DEFAULT_MOBILE_DEVICE
     type=click.Choice(["fast", "auto", "ocr", "off"], case_sensitive=False),
     default="auto",
     show_default=True,
-    help="PDF parsing mode. auto=detect PDFs and extract text (OCR fallback if available), fast=text only, ocr=force OCR, off=disable.",
+    help="PDF parsing mode. auto=detect .pdf URLs and extract text (OCR fallback if available), fast=text only, ocr=force OCR, off=disable.",
 )
 def scrape_url(
     url: str | None,

--- a/src/supacrawl/cli/scrape.py
+++ b/src/supacrawl/cli/scrape.py
@@ -162,6 +162,13 @@ from supacrawl.cli._common import app
     type=click.Choice(["git-diff", "json"], case_sensitive=False),
     help="Diff modes for change tracking. Requires -f changeTracking. Options: git-diff, json (requires --schema or --prompt).",
 )
+@click.option(
+    "--expand-iframes",
+    type=click.Choice(["none", "same-origin", "all"], case_sensitive=False),
+    default="same-origin",
+    show_default=True,
+    help="Iframe expansion mode. none=strip all, same-origin=expand same-origin inline, all=expand all non-blocked.",
+)
 def scrape_url(
     url: str,
     formats: tuple[str, ...],
@@ -186,6 +193,7 @@ def scrape_url(
     solve_captcha: bool,
     wait_until: str | None,
     change_tracking_modes: tuple[str, ...],
+    expand_iframes: str,
 ) -> None:
     """Scrape a single URL and extract content.
 
@@ -331,6 +339,7 @@ def scrape_url(
             max_age=max_age,
             wait_until=wait_until,  # type: ignore[arg-type]
             change_tracking_modes=list(change_tracking_modes) if change_tracking_modes else None,
+            expand_iframes=expand_iframes,  # type: ignore[arg-type]
         )
         return result
 

--- a/src/supacrawl/cli/scrape.py
+++ b/src/supacrawl/cli/scrape.py
@@ -5,10 +5,11 @@ from pathlib import Path
 import click
 
 from supacrawl.cli._common import app
+from supacrawl.models import DEFAULT_MOBILE_DEVICE
 
 
 @app.command("scrape", help="Scrape a single URL to markdown.")
-@click.argument("url")
+@click.argument("url", required=False, default=None)
 @click.option(
     "--format",
     "-f",
@@ -169,8 +170,25 @@ from supacrawl.cli._common import app
     show_default=True,
     help="Iframe expansion mode. none=strip all, same-origin=expand same-origin inline, all=expand all non-blocked.",
 )
+@click.option(
+    "--mobile/--no-mobile",
+    default=False,
+    help=f"Scrape as a mobile device (default: {DEFAULT_MOBILE_DEVICE}). Sets mobile viewport, user agent, and touch support.",
+)
+@click.option(
+    "--device",
+    type=str,
+    default=None,
+    help='Emulate a specific device (e.g. "iPhone 15", "Pixel 7"). Overrides --mobile. See --list-devices for options.',
+)
+@click.option(
+    "--list-devices",
+    is_flag=True,
+    default=False,
+    help="List available device presets and exit.",
+)
 def scrape_url(
-    url: str,
+    url: str | None,
     formats: tuple[str, ...],
     schema: Path | None,
     prompt: str | None,
@@ -194,6 +212,9 @@ def scrape_url(
     wait_until: str | None,
     change_tracking_modes: tuple[str, ...],
     expand_iframes: str,
+    mobile: bool,
+    device: str | None,
+    list_devices: bool,
 ) -> None:
     """Scrape a single URL and extract content.
 
@@ -246,10 +267,41 @@ def scrape_url(
         supacrawl scrape https://akamai-site.com --engine camoufox  # Tier 3: Akamai bypass
         supacrawl scrape https://captcha-site.com --stealth --solve-captcha  # Solve CAPTCHAs
         supacrawl scrape https://spa-site.com --wait-until networkidle  # Wait for JS to finish
+        supacrawl scrape https://example.com --mobile  # Scrape as default mobile device
+        supacrawl scrape https://example.com --device "iPhone 15"  # Scrape as iPhone 15
+        supacrawl scrape https://example.com --mobile -f screenshot -o mobile.png  # Mobile screenshot
+        supacrawl scrape --list-devices  # Show available device presets
     """
     import asyncio
     import base64
     import json
+
+    # Handle --list-devices: print available devices and exit
+    if list_devices:
+
+        async def _list():
+            from playwright.async_api import async_playwright
+
+            pw = await async_playwright().start()
+            try:
+                return sorted(pw.devices.keys())
+            finally:
+                await pw.stop()
+
+        devices = asyncio.run(_list())
+        for name in devices:
+            click.echo(name)
+        return
+
+    # URL is required when not listing devices
+    if not url:
+        click.echo("Error: Missing argument 'URL'.", err=True)
+        raise SystemExit(1)
+
+    # Resolve --mobile / --device to a device name
+    resolved_device: str | None = device
+    if mobile and not device:
+        resolved_device = DEFAULT_MOBILE_DEVICE
 
     from supacrawl.services.scrape import ScrapeService
 
@@ -340,6 +392,7 @@ def scrape_url(
             wait_until=wait_until,  # type: ignore[arg-type]
             change_tracking_modes=list(change_tracking_modes) if change_tracking_modes else None,
             expand_iframes=expand_iframes,  # type: ignore[arg-type]
+            device=resolved_device,
         )
         return result
 

--- a/src/supacrawl/cli/scrape.py
+++ b/src/supacrawl/cli/scrape.py
@@ -159,8 +159,8 @@ from supacrawl.cli._common import app
 @click.option(
     "--change-tracking-modes",
     multiple=True,
-    type=click.Choice(["git-diff"], case_sensitive=False),
-    help="Diff modes for change tracking. Requires -f changeTracking. Options: git-diff.",
+    type=click.Choice(["git-diff", "json"], case_sensitive=False),
+    help="Diff modes for change tracking. Requires -f changeTracking. Options: git-diff, json (requires --schema or --prompt).",
 )
 def scrape_url(
     url: str,

--- a/src/supacrawl/mcp/api_client.py
+++ b/src/supacrawl/mcp/api_client.py
@@ -154,6 +154,7 @@ async def create_supacrawl_services() -> SupacrawlServices:
         locale_config=locale_config,
         stealth=settings.stealth,
         proxy=settings.proxy,
+        engine=settings.engine,
     )
 
     # Initialise browser
@@ -161,6 +162,8 @@ async def create_supacrawl_services() -> SupacrawlServices:
 
     # Log enabled features
     features = []
+    if settings.engine:
+        features.append(f"engine:{settings.engine}")
     if settings.stealth:
         features.append("stealth")
     if settings.proxy:
@@ -183,6 +186,7 @@ async def create_supacrawl_services() -> SupacrawlServices:
         proxy=settings.proxy,
         solve_captcha=settings.solve_captcha,
         headless=settings.headless,
+        engine=settings.engine,
     )
     map_service = MapService(browser=browser_manager)
     crawl_service = CrawlService(

--- a/src/supacrawl/mcp/config.py
+++ b/src/supacrawl/mcp/config.py
@@ -43,6 +43,14 @@ class SupacrawlSettings(BaseSettings):
     )
 
     # Anti-bot protection
+    engine: Literal["playwright", "patchright", "camoufox"] | None = Field(
+        default=None,
+        description=(
+            "Browser engine to use. Options: playwright (default), patchright (stealth), "
+            "camoufox (Akamai/Cloudflare bypass). When not set, falls back to patchright "
+            "if stealth=True, else playwright. Per-request engine overrides this."
+        ),
+    )
     stealth: bool = Field(
         default=False,
         description="Enable enhanced stealth mode via Patchright (requires: pip install supacrawl[stealth])",

--- a/src/supacrawl/mcp/tools/crawl.py
+++ b/src/supacrawl/mcp/tools/crawl.py
@@ -20,9 +20,10 @@ async def supacrawl_crawl(
     max_depth: int = 3,
     include_patterns: list[str] | None = None,
     exclude_patterns: list[str] | None = None,
-    formats: list[Literal["markdown", "html", "rawHtml", "links", "screenshot"]] | None = None,
+    formats: list[Literal["markdown", "html", "rawHtml", "links", "screenshot", "changeTracking"]] | None = None,
     deduplicate_similar_urls: bool = False,
     allow_external_links: bool = False,
+    change_tracking_modes: list[str] | None = None,
 ) -> dict:
     """
     Crawl a website starting from URL, discovering and scraping pages.
@@ -64,9 +65,13 @@ async def supacrawl_crawl(
             - rawHtml: Full unprocessed HTML
             - links: Extracted links
             - screenshot: Page screenshots
+            - changeTracking: Compare each page against cached previous version
         deduplicate_similar_urls: Remove URLs that are similar (different query params,
             fragments, etc. pointing to same content)
         allow_external_links: Follow and crawl links to external domains
+        change_tracking_modes: Optional diff modes when changeTracking format is used.
+            Supports: ["git-diff", "json"]. git-diff produces unified diffs,
+            json compares extracted structured fields.
 
     Returns:
         Firecrawl-compatible crawl result:
@@ -117,8 +122,16 @@ async def supacrawl_crawl(
         # Convert Literal list to plain str list for CrawlService
         format_list: list[str] | None = list(formats) if formats else None
 
+        # Auto-resolve cache directory when change tracking is requested
+        cache_dir = None
+        if format_list and "changeTracking" in format_list:
+            from supacrawl.cache import CacheManager
+
+            cache_dir = CacheManager.DEFAULT_CACHE_DIR
+
         pages = []
         total_crawled = 0
+        change_summary = None
 
         # CrawlService.crawl() yields CrawlEvent objects
         async for event in api_client.crawl_service.crawl(
@@ -130,18 +143,25 @@ async def supacrawl_crawl(
             formats=format_list,
             deduplicate_similar_urls=deduplicate_similar_urls,
             allow_external_links=allow_external_links,
+            cache_dir=cache_dir,
+            change_tracking_modes=change_tracking_modes,
         ):
             if event.type == "page" and event.data:
                 pages.append(event.data.model_dump())
                 total_crawled += 1
+            elif event.type == "complete" and event.change_summary:
+                change_summary = event.change_summary
 
-        return {
+        result = {
             "success": True,
             "status": "completed",
             "total": total_crawled,
             "data": pages,
             "correlation_id": correlation_id,
         }
+        if change_summary:
+            result["change_summary"] = change_summary
+        return result
 
     except SupacrawlValidationError:
         raise

--- a/src/supacrawl/mcp/tools/crawl.py
+++ b/src/supacrawl/mcp/tools/crawl.py
@@ -24,6 +24,7 @@ async def supacrawl_crawl(
     deduplicate_similar_urls: bool = False,
     allow_external_links: bool = False,
     change_tracking_modes: list[str] | None = None,
+    expand_iframes: str = "same-origin",
 ) -> dict:
     """
     Crawl a website starting from URL, discovering and scraping pages.
@@ -72,6 +73,9 @@ async def supacrawl_crawl(
         change_tracking_modes: Optional diff modes when changeTracking format is used.
             Supports: ["git-diff", "json"]. git-diff produces unified diffs,
             json compares extracted structured fields.
+        expand_iframes: Iframe expansion mode (default: "same-origin").
+            "none" strips all iframes (legacy), "same-origin" expands same-origin
+            iframes inline, "all" expands all non-blocked iframes.
 
     Returns:
         Firecrawl-compatible crawl result:
@@ -145,6 +149,7 @@ async def supacrawl_crawl(
             allow_external_links=allow_external_links,
             cache_dir=cache_dir,
             change_tracking_modes=change_tracking_modes,
+            expand_iframes=expand_iframes,
         ):
             if event.type == "page" and event.data:
                 pages.append(event.data.model_dump())

--- a/src/supacrawl/mcp/tools/crawl.py
+++ b/src/supacrawl/mcp/tools/crawl.py
@@ -11,6 +11,7 @@ from supacrawl.mcp.api_client import SupacrawlServices
 from supacrawl.mcp.exceptions import SupacrawlValidationError, log_tool_exception, map_exception
 from supacrawl.mcp.mcp_common.correlation import generate_correlation_id, get_correlation_id
 from supacrawl.mcp.validators import validate_limit, validate_url
+from supacrawl.services.browser import ENGINE_CHOICES
 
 
 async def supacrawl_crawl(
@@ -25,6 +26,7 @@ async def supacrawl_crawl(
     allow_external_links: bool = False,
     change_tracking_modes: list[str] | None = None,
     expand_iframes: str = "same-origin",
+    engine: Literal["playwright", "patchright", "camoufox"] | None = None,
 ) -> dict:
     """
     Crawl a website starting from URL, discovering and scraping pages.
@@ -76,6 +78,8 @@ async def supacrawl_crawl(
         expand_iframes: Iframe expansion mode (default: "same-origin").
             "none" strips all iframes (legacy), "same-origin" expands same-origin
             iframes inline, "all" expands all non-blocked iframes.
+        engine: Browser engine to use for this crawl. Overrides server default.
+            Options: "playwright", "patchright", "camoufox".
 
     Returns:
         Firecrawl-compatible crawl result:
@@ -123,6 +127,9 @@ async def supacrawl_crawl(
         validated_limit = validate_limit(limit, "limit", min_value=1, max_value=1000, default=50)
         assert validated_limit is not None  # default=50 ensures non-None
 
+        if engine is not None and engine not in ENGINE_CHOICES:
+            raise SupacrawlValidationError(f"Invalid engine '{engine}'. Choose from: {', '.join(ENGINE_CHOICES)}")
+
         # Convert Literal list to plain str list for CrawlService
         format_list: list[str] | None = list(formats) if formats else None
 
@@ -150,6 +157,7 @@ async def supacrawl_crawl(
             cache_dir=cache_dir,
             change_tracking_modes=change_tracking_modes,
             expand_iframes=expand_iframes,
+            engine=engine,
         ):
             if event.type == "page" and event.data:
                 pages.append(event.data.model_dump())

--- a/src/supacrawl/mcp/tools/crawl.py
+++ b/src/supacrawl/mcp/tools/crawl.py
@@ -64,7 +64,7 @@ async def supacrawl_crawl(
             - markdown: Clean markdown with resolved URLs
             - html: Cleaned HTML
             - rawHtml: Full unprocessed HTML
-            - links: Extracted links
+            - links: Extracted links (parsed from rendered HTML)
             - screenshot: Page screenshots
             - changeTracking: Compare each page against cached previous version
         deduplicate_similar_urls: Remove URLs that are similar (different query params,

--- a/src/supacrawl/mcp/tools/diagnose.py
+++ b/src/supacrawl/mcp/tools/diagnose.py
@@ -203,7 +203,15 @@ def _generate_recommendations(
         wait_for = max(wait_for, 3000)
         reasons.append(f"JavaScript rendering required{f' ({framework} detected)' if framework else ''}")
 
-    if cdn == "cloudflare" or bot_indicators.get("challenge_detected"):
+    if cdn == "akamai":
+        recommendations["engine"] = "camoufox"
+        recommendations["stealth_mode"] = True
+        wait_for = max(wait_for, 5000)
+        reasons.append(
+            "Akamai Bot Manager detected - use --engine camoufox for best results "
+            "(requires: pip install supacrawl[camoufox])"
+        )
+    elif cdn == "cloudflare" or bot_indicators.get("challenge_detected"):
         recommendations["stealth_mode"] = True
         wait_for = max(wait_for, 5000)
         reasons.append("Bot protection detected - stealth mode recommended")

--- a/src/supacrawl/mcp/tools/scrape.py
+++ b/src/supacrawl/mcp/tools/scrape.py
@@ -43,6 +43,8 @@ async def supacrawl_scrape(
     max_age: int = 0,
     change_tracking_modes: list[str] | None = None,
     expand_iframes: str = "same-origin",
+    mobile: bool = False,
+    device: str | None = None,
 ) -> dict:
     """
     Scrape a single URL and return content in specified formats.
@@ -110,6 +112,11 @@ async def supacrawl_scrape(
         expand_iframes: Iframe expansion mode (default: "same-origin").
             "none" strips all iframes (legacy), "same-origin" expands same-origin
             iframes inline, "all" expands all non-blocked iframes.
+        mobile: Scrape as a default mobile device (iPhone 14). Sets mobile
+            viewport, user agent, device scale factor, and touch support.
+        device: Emulate a specific device by name (e.g. "iPhone 15", "Pixel 7").
+            Overrides the mobile flag. Uses Playwright's built-in device
+            descriptors for accurate viewport, user agent, and DPI emulation.
 
     Returns:
         Firecrawl-compatible scrape result:
@@ -170,6 +177,13 @@ async def supacrawl_scrape(
                 for a in actions
             ]
 
+        # Resolve mobile/device to a device name
+        from supacrawl.models import DEFAULT_MOBILE_DEVICE
+
+        resolved_device: str | None = device
+        if mobile and not device:
+            resolved_device = DEFAULT_MOBILE_DEVICE
+
         result = await api_client.scrape_service.scrape(
             url=validated_url,
             formats=formats,
@@ -185,6 +199,7 @@ async def supacrawl_scrape(
             max_age=max_age,
             change_tracking_modes=change_tracking_modes,
             expand_iframes=expand_iframes,  # type: ignore[arg-type]
+            device=resolved_device,
         )
 
         response = result.model_dump()

--- a/src/supacrawl/mcp/tools/scrape.py
+++ b/src/supacrawl/mcp/tools/scrape.py
@@ -10,6 +10,7 @@ from supacrawl.mcp.api_client import SupacrawlServices
 from supacrawl.mcp.exceptions import SupacrawlValidationError, log_tool_exception, map_exception
 from supacrawl.mcp.mcp_common.correlation import generate_correlation_id, get_correlation_id
 from supacrawl.mcp.validators import validate_timeout, validate_url
+from supacrawl.services.browser import ENGINE_CHOICES
 
 
 async def supacrawl_scrape(
@@ -46,6 +47,7 @@ async def supacrawl_scrape(
     mobile: bool = False,
     device: str | None = None,
     parse_pdf: str = "auto",
+    engine: Literal["playwright", "patchright", "camoufox"] | None = None,
 ) -> dict:
     """
     Scrape a single URL and return content in specified formats.
@@ -127,6 +129,11 @@ async def supacrawl_scrape(
             - "fast": Text extraction only (no OCR)
             - "ocr": Force OCR (requires supacrawl[pdf-ocr])
             - "off": Disable PDF parsing (render PDF in browser as before)
+        engine: Browser engine to use for this request. Overrides server default.
+            - "playwright" (default): Standard Chromium with basic stealth scripts
+            - "patchright": Patched Chromium for better anti-detection
+            - "camoufox": Patched Firefox for bypassing Akamai/Cloudflare
+            When not set, uses SUPACRAWL_ENGINE or auto-selects based on stealth config.
 
     Returns:
         Firecrawl-compatible scrape result:
@@ -164,6 +171,9 @@ async def supacrawl_scrape(
         validated_url = validate_url(url)
         assert validated_url is not None  # validate_url raises on None
         validated_timeout = validate_timeout(timeout, "timeout") or 30000
+
+        if engine is not None and engine not in ENGINE_CHOICES:
+            raise SupacrawlValidationError(f"Invalid engine '{engine}'. Choose from: {', '.join(ENGINE_CHOICES)}")
 
         if formats is None:
             formats = ["markdown"]
@@ -214,6 +224,7 @@ async def supacrawl_scrape(
             expand_iframes=expand_iframes,  # type: ignore[arg-type]
             device=resolved_device,
             parse_pdf=resolved_parse_pdf,  # type: ignore[arg-type]
+            engine=engine,
         )
 
         response = result.model_dump()

--- a/src/supacrawl/mcp/tools/scrape.py
+++ b/src/supacrawl/mcp/tools/scrape.py
@@ -65,6 +65,7 @@ async def supacrawl_scrape(
     - For clean article text: use only_main_content=True (default)
     - For full page including nav/footer: use only_main_content=False
     - If content is minimal/empty, try increasing wait_for (page may need time to load)
+    - If resources (images, CSS) must fully load: set wait_until="load"
     - For login-protected content: use actions to click buttons/fill forms first
     - For infinite scroll pages: use actions with scroll + wait sequences
 
@@ -81,7 +82,7 @@ async def supacrawl_scrape(
             - markdown: Clean markdown with resolved URLs (default)
             - html: Cleaned HTML with boilerplate removed
             - rawHtml: Full unprocessed HTML
-            - links: All extracted links
+            - links: All extracted links (parsed from rendered HTML)
             - images: All image URLs
             - screenshot: Base64-encoded PNG
             - pdf: Base64-encoded PDF document
@@ -89,7 +90,9 @@ async def supacrawl_scrape(
             - branding: Brand identity (colours, fonts, logo)
             - summary: LLM-generated 2-3 sentence summary
         only_main_content: Extract only main content, excluding headers/footers/sidebars
-        wait_for: Additional wait time in ms after page load (for dynamic content)
+        wait_for: Additional wait time in ms after page load (for dynamic content).
+            When set to a value > 0, also enables SPA stability polling which
+            waits for the DOM to stop changing before extracting content.
         timeout: Page load timeout in ms (default: 30000)
         screenshot_full_page: Capture full scrollable page vs viewport only
         actions: Page actions to execute before capturing content. Each action is a dict:

--- a/src/supacrawl/mcp/tools/scrape.py
+++ b/src/supacrawl/mcp/tools/scrape.py
@@ -27,6 +27,7 @@ async def supacrawl_scrape(
             "images",
             "branding",
             "summary",
+            "changeTracking",
         ]
     ]
     | None = None,
@@ -40,6 +41,7 @@ async def supacrawl_scrape(
     include_tags: list[str] | None = None,
     exclude_tags: list[str] | None = None,
     max_age: int = 0,
+    change_tracking_modes: list[str] | None = None,
 ) -> dict:
     """
     Scrape a single URL and return content in specified formats.
@@ -177,6 +179,7 @@ async def supacrawl_scrape(
             include_tags=include_tags,
             exclude_tags=exclude_tags,
             max_age=max_age,
+            change_tracking_modes=change_tracking_modes,
         )
 
         response = result.model_dump()

--- a/src/supacrawl/mcp/tools/scrape.py
+++ b/src/supacrawl/mcp/tools/scrape.py
@@ -42,6 +42,7 @@ async def supacrawl_scrape(
     exclude_tags: list[str] | None = None,
     max_age: int = 0,
     change_tracking_modes: list[str] | None = None,
+    expand_iframes: str = "same-origin",
 ) -> dict:
     """
     Scrape a single URL and return content in specified formats.
@@ -106,6 +107,9 @@ async def supacrawl_scrape(
             Example: ["nav", "footer", ".sidebar", ".ads"]
         max_age: Cache freshness in seconds. If cached version exists and is fresher,
             return cached result. Set to 0 to always fetch fresh (default).
+        expand_iframes: Iframe expansion mode (default: "same-origin").
+            "none" strips all iframes (legacy), "same-origin" expands same-origin
+            iframes inline, "all" expands all non-blocked iframes.
 
     Returns:
         Firecrawl-compatible scrape result:
@@ -180,6 +184,7 @@ async def supacrawl_scrape(
             exclude_tags=exclude_tags,
             max_age=max_age,
             change_tracking_modes=change_tracking_modes,
+            expand_iframes=expand_iframes,  # type: ignore[arg-type]
         )
 
         response = result.model_dump()

--- a/src/supacrawl/mcp/tools/scrape.py
+++ b/src/supacrawl/mcp/tools/scrape.py
@@ -45,12 +45,14 @@ async def supacrawl_scrape(
     expand_iframes: str = "same-origin",
     mobile: bool = False,
     device: str | None = None,
+    parse_pdf: str = "auto",
 ) -> dict:
     """
     Scrape a single URL and return content in specified formats.
 
     This is the primary tool for extracting content from web pages. It supports
     multiple output formats, page interactions, and LLM-powered extraction.
+    PDF URLs are auto-detected and text is extracted directly (no browser needed).
 
     **When to use this tool:**
     - You have a specific URL and need its content
@@ -117,6 +119,11 @@ async def supacrawl_scrape(
         device: Emulate a specific device by name (e.g. "iPhone 15", "Pixel 7").
             Overrides the mobile flag. Uses Playwright's built-in device
             descriptors for accurate viewport, user agent, and DPI emulation.
+        parse_pdf: PDF parsing mode (default: "auto"). Options:
+            - "auto": Auto-detect PDF URLs, extract text with OCR fallback
+            - "fast": Text extraction only (no OCR)
+            - "ocr": Force OCR (requires supacrawl[pdf-ocr])
+            - "off": Disable PDF parsing (render PDF in browser as before)
 
     Returns:
         Firecrawl-compatible scrape result:
@@ -184,6 +191,9 @@ async def supacrawl_scrape(
         if mobile and not device:
             resolved_device = DEFAULT_MOBILE_DEVICE
 
+        # Resolve parse_pdf mode
+        resolved_parse_pdf = parse_pdf if parse_pdf != "off" else None
+
         result = await api_client.scrape_service.scrape(
             url=validated_url,
             formats=formats,
@@ -200,6 +210,7 @@ async def supacrawl_scrape(
             change_tracking_modes=change_tracking_modes,
             expand_iframes=expand_iframes,  # type: ignore[arg-type]
             device=resolved_device,
+            parse_pdf=resolved_parse_pdf,  # type: ignore[arg-type]
         )
 
         response = result.model_dump()

--- a/src/supacrawl/mcp/tools/scrape.py
+++ b/src/supacrawl/mcp/tools/scrape.py
@@ -120,7 +120,7 @@ async def supacrawl_scrape(
             Overrides the mobile flag. Uses Playwright's built-in device
             descriptors for accurate viewport, user agent, and DPI emulation.
         parse_pdf: PDF parsing mode (default: "auto"). Options:
-            - "auto": Auto-detect PDF URLs, extract text with OCR fallback
+            - "auto": Auto-detect PDF URLs by .pdf extension, extract text with OCR fallback
             - "fast": Text extraction only (no OCR)
             - "ocr": Force OCR (requires supacrawl[pdf-ocr])
             - "off": Disable PDF parsing (render PDF in browser as before)

--- a/src/supacrawl/models.py
+++ b/src/supacrawl/models.py
@@ -320,6 +320,29 @@ class ActionsOutput(BaseModel):
     scrapes: list[ScrapeActionResult] | None = None  # Mid-workflow scrape captures
 
 
+class ChangeTrackingDiff(BaseModel):
+    """Unified diff output for change tracking."""
+
+    text: str  # Unified diff string
+
+
+class ChangeTrackingData(BaseModel):
+    """Change tracking result comparing current scrape to previous cached version.
+
+    Change statuses:
+        new — No previous cached version exists for this URL
+        same — Content hash matches the cached version (no meaningful change)
+        changed — Content differs from the cached version
+        removed — URL returns an error but a cached version exists
+    """
+
+    previous_scrape_at: str | None = None  # ISO timestamp of previous cached version
+    change_status: Literal["new", "same", "changed", "removed"]
+    visibility: Literal["visible", "hidden"] = "visible"
+    diff: ChangeTrackingDiff | None = None  # Git-style unified diff (when requested)
+    content_hash: str | None = None  # SHA256 hash of current markdown content
+
+
 class ScrapeData(BaseModel):
     """Scraped content from a page."""
 
@@ -337,6 +360,7 @@ class ScrapeData(BaseModel):
     actions: ActionsOutput | None = None  # Results from action sequence
     content_stats: ContentStats | None = None  # Content quality statistics
     process_metadata: ProcessMetadata | None = None  # Scraping process metadata
+    change_tracking: ChangeTrackingData | None = None  # Change detection vs previous scrape
 
     model_config = ConfigDict(populate_by_name=True)
 

--- a/src/supacrawl/models.py
+++ b/src/supacrawl/models.py
@@ -7,6 +7,13 @@ from typing import Any, Literal
 from pydantic import BaseModel, ConfigDict, Field
 
 # =============================================================================
+# Device Emulation
+# =============================================================================
+
+# Default device used by the --mobile shortcut
+DEFAULT_MOBILE_DEVICE = "iPhone 14"
+
+# =============================================================================
 # Locale/Location Configuration
 # =============================================================================
 

--- a/src/supacrawl/models.py
+++ b/src/supacrawl/models.py
@@ -340,6 +340,7 @@ class ChangeTrackingData(BaseModel):
     change_status: Literal["new", "same", "changed", "removed"]
     visibility: Literal["visible", "hidden"] = "visible"
     diff: ChangeTrackingDiff | None = None  # Git-style unified diff (when requested)
+    json_changes: dict[str, Any] | None = None  # Field-level JSON comparison {field: {previous, current}}
     content_hash: str | None = None  # SHA256 hash of current markdown content
 
 

--- a/src/supacrawl/models.py
+++ b/src/supacrawl/models.py
@@ -390,6 +390,7 @@ class CrawlEvent(BaseModel):
     total: int = 0  # 0 indicates unknown during mapping/discovery phase
     error: str | None = None
     message: str | None = None  # Descriptive text for mapping phase
+    change_summary: dict[str, int] | None = None  # Crawl-level change tracking summary
 
 
 # =============================================================================

--- a/src/supacrawl/models.py
+++ b/src/supacrawl/models.py
@@ -166,6 +166,11 @@ class ScrapeMetadata(BaseModel):
     # Content metrics (computed)
     word_count: int | None = None
 
+    # PDF document metadata (set when scraping a PDF URL)
+    pdf_page_count: int | None = None
+    pdf_author: str | None = None
+    pdf_creation_date: str | None = None
+
     # Cache metadata
     cache_hit: bool = False
     cached_at: str | None = None

--- a/src/supacrawl/services/browser.py
+++ b/src/supacrawl/services/browser.py
@@ -471,19 +471,76 @@ class BrowserManager:
             return default
         return val.strip().lower() in {"1", "true", "yes", "on"}
 
-    def _build_context_options(self) -> dict[str, Any]:
-        """Build browser context options including locale settings.
+    def _resolve_device_config(self, device: str) -> dict[str, Any]:
+        """Resolve a Playwright device name to context options.
+
+        Looks up the device in Playwright's built-in device descriptors and
+        returns a dict suitable for passing to ``browser.new_context()``.
+
+        Args:
+            device: Device name (e.g. "iPhone 14", "Pixel 7").
+
+        Returns:
+            Dict with user_agent, viewport, device_scale_factor, is_mobile,
+            has_touch keys.
+
+        Raises:
+            ValueError: If the device name is not found in Playwright's
+                device descriptors.
+        """
+        if self._playwright is None:
+            raise RuntimeError("Playwright not started. Cannot resolve device config.")
+
+        devices = self._playwright.devices
+        if device not in devices:
+            # Build helpful error with close matches
+            available = sorted(devices.keys())
+            lower = device.lower()
+            suggestions = [d for d in available if lower in d.lower() or d.lower() in lower][:5]
+            hint = f" Did you mean: {', '.join(suggestions)}" if suggestions else ""
+            raise ValueError(
+                f"Unknown device '{device}'. Use BrowserManager.list_devices() to see available devices.{hint}"
+            )
+
+        config = dict(devices[device])
+        # Remove default_browser_type — it's metadata, not a context option
+        config.pop("default_browser_type", None)
+        return config
+
+    async def list_devices(self) -> list[str]:
+        """Return sorted list of available Playwright device names.
+
+        Requires the browser to be started (Playwright instance available).
+        """
+        if self._playwright is None:
+            raise RuntimeError("Playwright not started. Call start() first.")
+        return sorted(self._playwright.devices.keys())
+
+    def _build_context_options(self, device: str | None = None) -> dict[str, Any]:
+        """Build browser context options including locale and device settings.
 
         When no explicit configuration is provided, returns minimal options
         to let Playwright use browser defaults. This reduces fingerprint
         mismatch that can trigger bot detection.
+
+        Args:
+            device: Optional Playwright device name for mobile emulation
+                (e.g. "iPhone 14", "Pixel 7").
 
         Returns:
             Dictionary of options for browser.new_context()
         """
         options: dict[str, Any] = {}
 
+        # Apply device emulation first (provides base viewport, UA, etc.)
+        if device:
+            device_config = self._resolve_device_config(device)
+            options.update(device_config)
+            LOGGER.debug("Applying device emulation: %s", device)
+
         # Only set user agent if explicitly provided (reduces fingerprint mismatch)
+        # When device emulation is active, the device's UA is already set above;
+        # an explicit user_agent overrides it (intentional user choice).
         if self.user_agent:
             options["user_agent"] = self.user_agent
 
@@ -677,6 +734,7 @@ class BrowserManager:
         actions: list[Any] | None = None,
         wait_until: Literal["commit", "domcontentloaded", "load", "networkidle"] | None = None,
         expand_iframes: Literal["none", "same-origin", "all"] = "same-origin",
+        device: str | None = None,
     ) -> PageContent:
         """Fetch a page with browser rendering.
 
@@ -693,15 +751,26 @@ class BrowserManager:
             expand_iframes: Iframe expansion mode. "none" strips all iframes (legacy),
                 "same-origin" expands same-origin iframes inline (default),
                 "all" expands all non-blocked iframes including cross-origin.
+            device: Playwright device name for mobile emulation (e.g. "iPhone 14",
+                "Pixel 7"). Sets viewport, user agent, device scale factor, and
+                touch support. Not supported with the Camoufox engine.
 
         Returns:
             PageContent with HTML, metadata, and optional screenshot/PDF
 
         Raises:
             RuntimeError: If browser not initialized or fetch fails
+            ValueError: If device is specified with Camoufox engine or device
+                name is not recognised.
         """
         if not self._browser:
             raise RuntimeError("Browser not initialized. Use 'async with BrowserManager()' context manager.")
+
+        if device and self.engine == "camoufox":
+            raise ValueError(
+                "Device emulation is not supported with the Camoufox engine. "
+                "Camoufox generates its own fingerprint. Use --engine playwright or --engine patchright."
+            )
 
         context: BrowserContext | None = None
         page: Page | None = None
@@ -711,7 +780,7 @@ class BrowserManager:
         try:
             if owns_context:
                 # Playwright/Patchright: create fresh context for isolation
-                context_options = self._build_context_options()
+                context_options = self._build_context_options(device=device)
                 context = await self._browser.new_context(**context_options)
                 page = await context.new_page()
             else:

--- a/src/supacrawl/services/browser.py
+++ b/src/supacrawl/services/browser.py
@@ -1,19 +1,26 @@
 """Browser manager for Playwright-based page fetching.
 
-ANTI-BOT PROTECTION (automatic, no configuration needed):
-    The following evasions are applied by default to every page:
-    - navigator.webdriver = false (hides automation)
-    - Chrome runtime objects (window.chrome.runtime, etc.)
-    - Non-empty plugins array (avoids empty plugins fingerprint)
-    - Standard languages array (['en-US', 'en'])
-    - WebGL vendor/renderer spoofing (Intel Inc. / Intel Iris OpenGL Engine)
-    - Canvas fingerprint noise (unique per session, non-destructive)
-    - Standard browser headers (Accept-Language, Sec-Fetch-*, etc.)
+ANTI-BOT PROTECTION (three tiers):
 
-ENHANCED STEALTH (optional, for heavily protected sites):
-    Install: pip install supacrawl[stealth]
-    Usage: BrowserManager(stealth=True) or --stealth flag
-    Provides: Full Patchright browser with advanced anti-detection
+    Tier 1 - Basic stealth scripts (always active, no configuration):
+        - navigator.webdriver = false (hides automation)
+        - Chrome runtime objects (window.chrome.runtime, etc.)
+        - Non-empty plugins array (avoids empty plugins fingerprint)
+        - Standard languages array (['en-US', 'en'])
+        - WebGL vendor/renderer spoofing (Intel Inc. / Intel Iris OpenGL Engine)
+        - Canvas fingerprint noise (unique per session, non-destructive)
+        - Standard browser headers (Accept-Language, Sec-Fetch-*, etc.)
+
+    Tier 2 - Patchright (optional, for heavily protected sites):
+        Install: pip install supacrawl[stealth]
+        Usage: BrowserManager(stealth=True) or --stealth flag or --engine patchright
+        Provides: Patched Chromium with enhanced anti-detection
+
+    Tier 3 - Camoufox (optional, for Akamai and advanced bot detection):
+        Install: pip install supacrawl[camoufox]
+        Usage: BrowserManager(engine="camoufox") or --engine camoufox
+        Provides: Patched Firefox with C++ engine-level anti-detection
+        Effective against: Akamai Bot Manager, advanced TLS fingerprinting
 
 CAPTCHA SOLVING (optional, requires third-party service):
     Install: pip install supacrawl[captcha]
@@ -248,6 +255,17 @@ class StealthNotAvailableError(ImportError):
         super().__init__("Stealth mode requires patchright. Install with: pip install supacrawl[stealth]")
 
 
+class CamoufoxNotAvailableError(ImportError):
+    """Raised when Camoufox engine is requested but camoufox is not installed."""
+
+    def __init__(self) -> None:
+        super().__init__("Camoufox engine requires camoufox. Install with: pip install supacrawl[camoufox]")
+
+
+# Valid engine choices
+ENGINE_CHOICES = ("playwright", "patchright", "camoufox")
+
+
 @dataclass
 class PageContent:
     """Result of fetching a page."""
@@ -350,6 +368,7 @@ class BrowserManager:
         locale_config: Any | None = None,  # LocaleConfig, avoid circular import
         stealth: bool = False,
         proxy: str | None = None,
+        engine: str | None = None,
     ):
         """Initialize browser manager.
 
@@ -357,28 +376,52 @@ class BrowserManager:
             headless: Run headless (default from SUPACRAWL_HEADLESS env, or True).
                 Note: When stealth=True and headless is not explicitly set, defaults
                 to False (headful) because stealth mode is more effective headful.
+                Camoufox supports headless=True with humanize=True effectively.
             timeout_ms: Page load timeout (default from SUPACRAWL_TIMEOUT env, or 30000)
             user_agent: User agent string (default from SUPACRAWL_USER_AGENT env)
             locale_config: LocaleConfig for browser locale/timezone settings
             stealth: Enable stealth mode via Patchright for anti-bot evasion.
                 Automatically enables headful mode unless headless is explicitly set.
+                Ignored when engine is explicitly set.
             proxy: Proxy URL (e.g., http://user:pass@host:port, socks5://host:port)
+            engine: Browser engine to use. Options:
+                - "playwright" (default): Standard Playwright Chromium with basic stealth scripts
+                - "patchright": Patched Chromium via Patchright (Tier 2 anti-detection)
+                - "camoufox": Patched Firefox via Camoufox (Tier 3 anti-detection,
+                  effective against Akamai Bot Manager)
+                When not set, falls back to "patchright" if stealth=True, else "playwright".
         """
-        # Stealth mode works best headful - default to headful when stealth enabled
-        # unless user explicitly sets headless
+        # Resolve engine from explicit engine param, stealth flag, or default
+        if engine is not None:
+            if engine not in ENGINE_CHOICES:
+                raise ValueError(f"Invalid engine '{engine}'. Choose from: {', '.join(ENGINE_CHOICES)}")
+            self.engine = engine
+        elif stealth:
+            self.engine = "patchright"
+        else:
+            self.engine = "playwright"
+
+        # Keep stealth flag for backwards compat (True when engine is patchright or camoufox)
+        self.stealth = self.engine in ("patchright", "camoufox")
+
+        # Headless defaults: Patchright prefers headful, Camoufox works headless
         if headless is not None:
             self.headless = headless
-        elif stealth:
-            # Stealth + headless has worse detection scores than stealth + headful
+        elif self.engine == "patchright":
+            # Patchright + headless has worse detection scores than headful
             self.headless = self._env_bool("SUPACRAWL_HEADLESS", False)
+        elif self.engine == "camoufox":
+            # Camoufox works well headless with humanize=True
+            self.headless = self._env_bool("SUPACRAWL_HEADLESS", True)
         else:
             self.headless = self._env_bool("SUPACRAWL_HEADLESS", True)
+
         self.timeout_ms = timeout_ms or int(os.getenv("SUPACRAWL_TIMEOUT", "30000"))
         # Only set user_agent if explicitly provided or env var is set
         # Otherwise let Playwright use its real browser UA (reduces fingerprint mismatch)
+        # Note: Camoufox generates its own fingerprint, so user_agent is not set for it
         self.user_agent = user_agent or os.getenv("SUPACRAWL_USER_AGENT")
         self.locale_config = locale_config
-        self.stealth = stealth
         self.proxy = proxy or os.getenv("SUPACRAWL_PROXY")
         self._browser: Browser | None = None
         self._playwright: Any = None
@@ -446,19 +489,30 @@ class BrowserManager:
         await self.stop()
 
     def _get_playwright_module(self) -> Any:
-        """Get the appropriate playwright module based on stealth setting.
+        """Get the appropriate playwright module based on engine setting.
 
         Returns:
             The async_playwright function from either patchright or playwright.
+            Returns None when engine is "camoufox" (uses separate launch path).
 
         Raises:
-            StealthNotAvailableError: If stealth is enabled but patchright not installed.
+            StealthNotAvailableError: If patchright engine requested but not installed.
+            CamoufoxNotAvailableError: If camoufox engine requested but not installed.
         """
-        if self.stealth:
+        if self.engine == "camoufox":
+            # Camoufox has its own launch path, validated in start()
+            try:
+                import camoufox  # noqa: F401
+
+                LOGGER.debug("Using Camoufox engine (patched Firefox)")
+                return None  # Camoufox doesn't use async_playwright
+            except ImportError as e:
+                raise CamoufoxNotAvailableError() from e
+        elif self.engine == "patchright":
             try:
                 from patchright.async_api import async_playwright
 
-                LOGGER.debug("Using Patchright for stealth mode")
+                LOGGER.debug("Using Patchright engine (patched Chromium)")
                 return async_playwright
             except ImportError as e:
                 raise StealthNotAvailableError() from e
@@ -474,11 +528,19 @@ class BrowserManager:
         via async context manager (async with BrowserManager() as browser).
 
         Raises:
-            StealthNotAvailableError: If stealth is enabled but patchright not installed.
+            StealthNotAvailableError: If patchright engine requested but not installed.
+            CamoufoxNotAvailableError: If camoufox engine requested but not installed.
         """
         if self._browser is not None:
             return  # Already started
 
+        if self.engine == "camoufox":
+            await self._start_camoufox()
+        else:
+            await self._start_playwright()
+
+    async def _start_playwright(self) -> None:
+        """Start browser via Playwright or Patchright."""
         async_playwright = self._get_playwright_module()
         self._playwright = await async_playwright().start()
 
@@ -496,9 +558,52 @@ class BrowserManager:
 
         self._browser = await self._playwright.chromium.launch(**launch_options)
         LOGGER.debug(
-            "Browser started (headless=%s, stealth=%s, proxy=%s)",
+            "Browser started (engine=%s, headless=%s, proxy=%s)",
+            self.engine,
             self.headless,
-            self.stealth,
+            bool(self.proxy),
+        )
+
+    async def _start_camoufox(self) -> None:
+        """Start browser via Camoufox (patched Firefox).
+
+        Camoufox has its own context manager that returns a browser instance
+        compatible with the Playwright API. We use AsyncNewBrowser to get
+        an async context manager.
+        """
+        try:
+            from camoufox.async_api import AsyncNewBrowser
+        except ImportError as e:
+            raise CamoufoxNotAvailableError() from e
+
+        # Build Camoufox options
+        camoufox_options: dict[str, Any] = {
+            "headless": self.headless,
+            "humanize": True,  # Natural cursor movement
+        }
+
+        # Add proxy if configured
+        if self.proxy:
+            try:
+                camoufox_options["proxy"] = _parse_proxy_url(self.proxy)
+                LOGGER.debug("Using proxy: %s", self.proxy.split("@")[-1])
+            except ValueError as e:
+                LOGGER.error(f"Invalid proxy URL: {e}")
+                raise
+
+        # Apply locale if configured
+        if self.locale_config is not None:
+            locale = self.locale_config.get_language()
+            if locale:
+                camoufox_options["locale"] = locale
+
+        # Camoufox returns a context manager; we enter it and store the browser
+        self._camoufox_cm = AsyncNewBrowser(**camoufox_options)
+        self._browser = await self._camoufox_cm.__aenter__()
+
+        LOGGER.debug(
+            "Browser started (engine=camoufox, headless=%s, humanize=True, proxy=%s)",
+            self.headless,
             bool(self.proxy),
         )
 
@@ -507,12 +612,21 @@ class BrowserManager:
 
         Safe to call multiple times.
         """
-        if self._browser:
-            await self._browser.close()
+        if self.engine == "camoufox" and hasattr(self, "_camoufox_cm"):
+            # Camoufox cleanup via its context manager
+            try:
+                await self._camoufox_cm.__aexit__(None, None, None)
+            except Exception:
+                pass
             self._browser = None
-        if self._playwright:
-            await self._playwright.stop()
-            self._playwright = None
+            del self._camoufox_cm
+        else:
+            if self._browser:
+                await self._browser.close()
+                self._browser = None
+            if self._playwright:
+                await self._playwright.stop()
+                self._playwright = None
         LOGGER.debug("Browser stopped")
 
     async def fetch_page(
@@ -550,17 +664,22 @@ class BrowserManager:
 
         context: BrowserContext | None = None
         page: Page | None = None
+        # Camoufox browser IS the context — don't create a separate one
+        owns_context = self.engine != "camoufox"
 
         try:
-            # Create fresh context for isolation with locale settings
-            context_options = self._build_context_options()
-            context = await self._browser.new_context(**context_options)
+            if owns_context:
+                # Playwright/Patchright: create fresh context for isolation
+                context_options = self._build_context_options()
+                context = await self._browser.new_context(**context_options)
+                page = await context.new_page()
+            else:
+                # Camoufox: browser is already a context, just create a page
+                page = await self._browser.new_page()
 
-            page = await context.new_page()
-
-            # Inject basic stealth scripts (for non-Patchright mode)
-            # Patchright handles these automatically, but we add them for standard Playwright
-            if not self.stealth:
+            # Inject basic stealth scripts only for standard Playwright
+            # Patchright and Camoufox handle anti-detection at the engine level
+            if self.engine == "playwright":
                 for script in STEALTH_SCRIPTS:
                     await page.add_init_script(script)
                 LOGGER.debug("Injected %d basic stealth scripts", len(STEALTH_SCRIPTS))
@@ -610,13 +729,18 @@ class BrowserManager:
                     type="png",
                 )
 
-            # Generate PDF if requested (requires headless mode)
+            # Generate PDF if requested
+            # Note: page.pdf() is only available on Chromium (Playwright/Patchright),
+            # not on Firefox (Camoufox). Log a warning instead of crashing.
             pdf_bytes: bytes | None = None
             if capture_pdf:
-                pdf_bytes = await page.pdf(
-                    format="A4",
-                    print_background=True,
-                )
+                if self.engine == "camoufox":
+                    LOGGER.warning("PDF generation is not supported with Camoufox (Firefox). Skipping PDF capture.")
+                else:
+                    pdf_bytes = await page.pdf(
+                        format="A4",
+                        print_background=True,
+                    )
 
             return PageContent(
                 url=url,
@@ -634,7 +758,7 @@ class BrowserManager:
                     await page.close()
                 except Exception:
                     pass
-            if context:
+            if owns_context and context:
                 try:
                     await context.close()
                 except Exception:
@@ -663,17 +787,18 @@ class BrowserManager:
 
         context: BrowserContext | None = None
         page: Page | None = None
+        owns_context = self.engine != "camoufox"
 
         try:
-            # Create fresh context with locale settings
-            context_options = self._build_context_options()
-            context = await self._browser.new_context(**context_options)
+            if owns_context:
+                context_options = self._build_context_options()
+                context = await self._browser.new_context(**context_options)
+                page = await context.new_page()
+            else:
+                page = await self._browser.new_page()
 
-            page = await context.new_page()
-
-            # Inject basic stealth scripts (for non-Patchright mode)
-            # Patchright handles these automatically, but we add them for standard Playwright
-            if not self.stealth:
+            # Inject basic stealth scripts only for standard Playwright
+            if self.engine == "playwright":
                 for script in STEALTH_SCRIPTS:
                     await page.add_init_script(script)
                 LOGGER.debug("Injected %d basic stealth scripts for link extraction", len(STEALTH_SCRIPTS))
@@ -708,7 +833,7 @@ class BrowserManager:
                     await page.close()
                 except Exception:
                     pass
-            if context:
+            if owns_context and context:
                 try:
                     await context.close()
                 except Exception:

--- a/src/supacrawl/services/browser.py
+++ b/src/supacrawl/services/browser.py
@@ -265,6 +265,43 @@ class CamoufoxNotAvailableError(ImportError):
 # Valid engine choices
 ENGINE_CHOICES = ("playwright", "patchright", "camoufox")
 
+# Domains to skip when expanding iframes (ads, analytics, tracking, CAPTCHA)
+IFRAME_BLOCKED_DOMAINS = frozenset(
+    {
+        # Advertising
+        "doubleclick.net",
+        "googlesyndication.com",
+        "amazon-adsystem.com",
+        "adnxs.com",
+        "adsrvr.org",
+        "moatads.com",
+        "taboola.com",
+        "outbrain.com",
+        # Analytics / tracking
+        "google-analytics.com",
+        "googletagmanager.com",
+        "analytics.google.com",
+        "connect.facebook.net",
+        "bat.bing.com",
+        "sc-static.net",
+        "hotjar.com",
+        "clarity.ms",
+        # CAPTCHA
+        "recaptcha.net",
+        "hcaptcha.com",
+        "challenges.cloudflare.com",
+    }
+)
+
+# Maximum iframes to expand per page (performance guard)
+MAX_IFRAMES_PER_PAGE = 10
+
+
+def _is_blocked_iframe_domain(hostname: str) -> bool:
+    """Check if hostname matches a blocked iframe domain."""
+    hostname = hostname.lower()
+    return any(hostname == domain or hostname.endswith("." + domain) for domain in IFRAME_BLOCKED_DOMAINS)
+
 
 @dataclass
 class PageContent:
@@ -639,6 +676,7 @@ class BrowserManager:
         screenshot_full_page: bool = True,
         actions: list[Any] | None = None,
         wait_until: Literal["commit", "domcontentloaded", "load", "networkidle"] | None = None,
+        expand_iframes: Literal["none", "same-origin", "all"] = "same-origin",
     ) -> PageContent:
         """Fetch a page with browser rendering.
 
@@ -652,6 +690,9 @@ class BrowserManager:
             actions: List of Action objects to execute before capturing content
             wait_until: Page load strategy. Options: commit, domcontentloaded (default),
                 load, networkidle. Falls back to SUPACRAWL_WAIT_UNTIL env var if None.
+            expand_iframes: Iframe expansion mode. "none" strips all iframes (legacy),
+                "same-origin" expands same-origin iframes inline (default),
+                "all" expands all non-blocked iframes including cross-origin.
 
         Returns:
             PageContent with HTML, metadata, and optional screenshot/PDF
@@ -716,6 +757,10 @@ class BrowserManager:
             if wait_until_resolved != "networkidle":
                 await asyncio.sleep(0.5)
 
+            # Expand iframe content inline before extracting HTML
+            if expand_iframes != "none":
+                await self._expand_iframes(page, mode=expand_iframes)
+
             # Extract HTML and title
             html = await page.content()
             title = await page.title() or None
@@ -763,6 +808,95 @@ class BrowserManager:
                     await context.close()
                 except Exception:
                     pass
+
+    async def _expand_iframes(
+        self,
+        page: Page,
+        mode: Literal["same-origin", "all"] = "same-origin",
+    ) -> int:
+        """Expand iframe content inline in the page DOM.
+
+        Replaces ``<iframe>`` elements with ``<div>`` wrappers containing the
+        frame body HTML so that the content is captured by ``page.content()``.
+
+        Args:
+            page: Playwright page with loaded content
+            mode: "same-origin" expands only same-origin frames,
+                  "all" expands all non-blocked frames
+
+        Returns:
+            Number of iframes expanded
+        """
+        page_origin = urlparse(page.url).scheme + "://" + urlparse(page.url).netloc
+
+        # Process frames innermost-first so nested content is captured
+        frames = list(page.frames)
+        frames.reverse()
+
+        expanded = 0
+
+        for frame in frames:
+            if frame == page.main_frame:
+                continue
+            if expanded >= MAX_IFRAMES_PER_PAGE:
+                LOGGER.debug("Reached max iframe expansion limit (%d)", MAX_IFRAMES_PER_PAGE)
+                break
+
+            frame_url = frame.url
+            if not frame_url or frame_url == "about:blank":
+                continue
+
+            # Check blocked domains
+            frame_hostname = urlparse(frame_url).hostname or ""
+            if _is_blocked_iframe_domain(frame_hostname):
+                LOGGER.debug("Skipping blocked iframe domain: %s", frame_hostname)
+                continue
+
+            # Same-origin check
+            if mode == "same-origin":
+                frame_origin = urlparse(frame_url).scheme + "://" + urlparse(frame_url).netloc
+                if frame_origin != page_origin:
+                    continue
+
+            try:
+                iframe_element = await frame.frame_element()
+
+                # Skip tracking pixels (very small iframes)
+                bounding = await iframe_element.bounding_box()
+                if bounding and (bounding["width"] <= 5 or bounding["height"] <= 5):
+                    LOGGER.debug("Skipping tracking-pixel iframe: %s", frame_url)
+                    continue
+
+                # Extract frame body content
+                body_html = await frame.evaluate("document.body ? document.body.innerHTML : ''")
+                if not body_html or not body_html.strip():
+                    continue
+
+                # Replace the <iframe> element with a <div> containing the content
+                await iframe_element.evaluate(
+                    """(el, args) => {
+                        const [bodyHtml, src, hostname] = args;
+                        const wrapper = document.createElement('div');
+                        wrapper.setAttribute('data-sc-iframe-src', src);
+                        const marker = document.createElement('p');
+                        marker.innerHTML = '<em>[Embedded content from ' + hostname + ']</em>';
+                        wrapper.appendChild(marker);
+                        const content = document.createElement('div');
+                        content.innerHTML = bodyHtml;
+                        wrapper.appendChild(content);
+                        el.replaceWith(wrapper);
+                    }""",
+                    [body_html, frame_url, frame_hostname],
+                )
+                expanded += 1
+
+            except Exception as e:
+                LOGGER.debug("Could not expand iframe %s: %s", frame_url, e)
+                continue
+
+        if expanded > 0:
+            LOGGER.info("Expanded %d iframe(s) inline", expanded)
+        return expanded
 
     async def extract_links(
         self,

--- a/src/supacrawl/services/browser.py
+++ b/src/supacrawl/services/browser.py
@@ -406,6 +406,7 @@ class BrowserManager:
         stealth: bool = False,
         proxy: str | None = None,
         engine: str | None = None,
+        firefox_user_prefs: dict[str, Any] | None = None,
     ):
         """Initialize browser manager.
 
@@ -427,6 +428,9 @@ class BrowserManager:
                 - "camoufox": Patched Firefox via Camoufox (Tier 3 anti-detection,
                   effective against Akamai Bot Manager)
                 When not set, falls back to "patchright" if stealth=True, else "playwright".
+            firefox_user_prefs: Firefox about:config preferences for Camoufox.
+                Only used when engine="camoufox". Example:
+                {"network.http.http2.enabled": False} to force HTTP/1.1.
         """
         # Resolve engine from explicit engine param, stealth flag, or default
         if engine is not None:
@@ -460,6 +464,7 @@ class BrowserManager:
         self.user_agent = user_agent or os.getenv("SUPACRAWL_USER_AGENT")
         self.locale_config = locale_config
         self.proxy = proxy or os.getenv("SUPACRAWL_PROXY")
+        self.firefox_user_prefs = firefox_user_prefs
         self._browser: Browser | None = None
         self._playwright: Any = None
 
@@ -691,14 +696,19 @@ class BrowserManager:
             if locale:
                 camoufox_options["locale"] = locale
 
+        # Apply Firefox user preferences (e.g. disable HTTP/2)
+        if self.firefox_user_prefs:
+            camoufox_options["firefox_user_prefs"] = self.firefox_user_prefs
+
         # Camoufox returns a context manager; we enter it and store the browser
         self._camoufox_cm = AsyncCamoufox(**camoufox_options)
         self._browser = await self._camoufox_cm.__aenter__()
 
         LOGGER.debug(
-            "Browser started (engine=camoufox, headless=%s, humanize=True, proxy=%s)",
+            "Browser started (engine=camoufox, headless=%s, humanize=True, proxy=%s, firefox_prefs=%s)",
             self.headless,
             bool(self.proxy),
+            bool(self.firefox_user_prefs),
         )
 
     async def stop(self) -> None:

--- a/src/supacrawl/services/browser.py
+++ b/src/supacrawl/services/browser.py
@@ -661,12 +661,12 @@ class BrowserManager:
     async def _start_camoufox(self) -> None:
         """Start browser via Camoufox (patched Firefox).
 
-        Camoufox has its own context manager that returns a browser instance
-        compatible with the Playwright API. We use AsyncNewBrowser to get
-        an async context manager.
+        Camoufox provides AsyncCamoufox, an async context manager that
+        handles Playwright acquisition internally and returns a browser
+        instance compatible with the Playwright API.
         """
         try:
-            from camoufox.async_api import AsyncNewBrowser
+            from camoufox.async_api import AsyncCamoufox
         except ImportError as e:
             raise CamoufoxNotAvailableError() from e
 
@@ -692,7 +692,7 @@ class BrowserManager:
                 camoufox_options["locale"] = locale
 
         # Camoufox returns a context manager; we enter it and store the browser
-        self._camoufox_cm = AsyncNewBrowser(**camoufox_options)
+        self._camoufox_cm = AsyncCamoufox(**camoufox_options)
         self._browser = await self._camoufox_cm.__aenter__()
 
         LOGGER.debug(

--- a/src/supacrawl/services/browser.py
+++ b/src/supacrawl/services/browser.py
@@ -782,25 +782,26 @@ class BrowserManager:
                 # Playwright/Patchright: create fresh context for isolation
                 context_options = self._build_context_options(device=device)
                 context = await self._browser.new_context(**context_options)
+
+                # Inject stealth scripts at context level so all pages inherit them.
+                # Patchright and Camoufox handle anti-detection at the engine level.
+                if self.engine == "playwright":
+                    for script in STEALTH_SCRIPTS:
+                        await context.add_init_script(script)
+                    LOGGER.debug("Injected %d stealth scripts at context level", len(STEALTH_SCRIPTS))
+
                 page = await context.new_page()
             else:
                 # Camoufox: browser is already a context, just create a page
                 page = await self._browser.new_page()
 
-            # Inject basic stealth scripts only for standard Playwright
-            # Patchright and Camoufox handle anti-detection at the engine level
-            if self.engine == "playwright":
-                for script in STEALTH_SCRIPTS:
-                    await page.add_init_script(script)
-                LOGGER.debug("Injected %d basic stealth scripts", len(STEALTH_SCRIPTS))
-
             # Navigate to URL - use parameter if provided, else fall back to env var
             if wait_until is None:
-                wait_until_env = os.getenv("SUPACRAWL_WAIT_UNTIL", "load")
+                wait_until_env = os.getenv("SUPACRAWL_WAIT_UNTIL", "domcontentloaded")
                 wait_until_resolved: Literal["commit", "domcontentloaded", "load", "networkidle"] = (
                     wait_until_env  # type: ignore[assignment]
                     if wait_until_env in ("commit", "domcontentloaded", "load", "networkidle")
-                    else "load"
+                    else "domcontentloaded"
                 )
             else:
                 wait_until_resolved = wait_until
@@ -820,11 +821,6 @@ class BrowserManager:
                 runner = ActionRunner(timeout_ms=self.timeout_ms)
                 action_results_list = await runner.run(page, actions)
                 LOGGER.debug(f"Executed {len(action_results_list)} actions")
-
-            # Additional fixed delay for any remaining JS execution
-            # Skip when using networkidle - it already waits for JS to settle
-            if wait_until_resolved != "networkidle":
-                await asyncio.sleep(0.5)
 
             # Expand iframe content inline before extracting HTML
             if expand_iframes != "none":
@@ -996,23 +992,23 @@ class BrowserManager:
             if owns_context:
                 context_options = self._build_context_options()
                 context = await self._browser.new_context(**context_options)
+
+                if self.engine == "playwright":
+                    for script in STEALTH_SCRIPTS:
+                        await context.add_init_script(script)
+                    LOGGER.debug("Injected %d stealth scripts at context level", len(STEALTH_SCRIPTS))
+
                 page = await context.new_page()
             else:
                 page = await self._browser.new_page()
 
-            # Inject basic stealth scripts only for standard Playwright
-            if self.engine == "playwright":
-                for script in STEALTH_SCRIPTS:
-                    await page.add_init_script(script)
-                LOGGER.debug("Injected %d basic stealth scripts for link extraction", len(STEALTH_SCRIPTS))
-
             # Navigate to URL - use parameter if provided, else fall back to env var
             if wait_until is None:
-                wait_until_env = os.getenv("SUPACRAWL_WAIT_UNTIL", "load")
+                wait_until_env = os.getenv("SUPACRAWL_WAIT_UNTIL", "domcontentloaded")
                 wait_until_resolved: Literal["commit", "domcontentloaded", "load", "networkidle"] = (
                     wait_until_env  # type: ignore[assignment]
                     if wait_until_env in ("commit", "domcontentloaded", "load", "networkidle")
-                    else "load"
+                    else "domcontentloaded"
                 )
             else:
                 wait_until_resolved = wait_until
@@ -1126,8 +1122,24 @@ class BrowserManager:
 
         return sorted(filtered_images)
 
+    @staticmethod
+    def _extract_head_section(html: str) -> str:
+        """Extract the head section from HTML for lightweight metadata parsing.
+
+        Includes everything from document start through ``</head>``, which
+        captures ``<html lang="...">`` and the full ``<head>`` block. Falls
+        back to the full HTML if ``<head>`` boundaries are not found.
+        """
+        head_end = html.lower().find("</head>")
+        if head_end == -1:
+            return html
+        return html[: head_end + len("</head>")]
+
     async def extract_metadata(self, html: str) -> PageMetadata:
         """Extract metadata from HTML.
+
+        Only parses the ``<head>`` section for efficiency, since all metadata
+        tags (title, meta, link, structured data) appear there.
 
         Args:
             html: HTML content
@@ -1135,7 +1147,8 @@ class BrowserManager:
         Returns:
             PageMetadata with title, description, og tags, and other metadata
         """
-        soup = BeautifulSoup(html, "html.parser")
+        head_html = self._extract_head_section(html)
+        soup = BeautifulSoup(head_html, "html.parser")
 
         def get_meta_content(name: str | None = None, property: str | None = None) -> str | None:
             """Helper to extract meta tag content."""

--- a/src/supacrawl/services/crawl.py
+++ b/src/supacrawl/services/crawl.py
@@ -71,6 +71,7 @@ class CrawlService:
         concurrency: int = 10,
         wait_until: WaitUntilType | None = None,
         headless: bool | None = None,
+        engine: str | None = None,
     ) -> AsyncGenerator[CrawlEvent, None]:
         """Crawl a website, yielding events as pages complete.
 
@@ -88,7 +89,8 @@ class CrawlService:
             allow_external_links: Follow and scrape links to external domains
                 (default: False)
             locale_config: Optional LocaleConfig for browser locale/timezone settings
-            stealth: Enable stealth mode via Patchright for anti-bot evasion
+            stealth: Enable stealth mode via Patchright for anti-bot evasion.
+                Ignored when engine is explicitly set.
             proxy: Proxy URL (e.g., http://user:pass@host:port, socks5://host:port)
             save_files: Save scraped content files to output_dir (default: True).
                 When False with output_dir set, only manifest.json is saved for
@@ -98,6 +100,8 @@ class CrawlService:
                 load, networkidle. Falls back to SUPACRAWL_WAIT_UNTIL env var if None.
             headless: Run browser in headless mode. Only used when CrawlService
                 creates its own BrowserManager (i.e. no injected browser).
+            engine: Browser engine ("playwright", "patchright", "camoufox").
+                Overrides the stealth flag when set.
 
         Yields:
             CrawlEvent for each page and progress update
@@ -139,6 +143,7 @@ class CrawlService:
                     locale_config=locale_config,
                     stealth=stealth,
                     proxy=proxy,
+                    engine=engine,
                 ) as browser:
                     self._browser = browser
                     self._map_service = MapService(

--- a/src/supacrawl/services/crawl.py
+++ b/src/supacrawl/services/crawl.py
@@ -74,6 +74,7 @@ class CrawlService:
         engine: str | None = None,
         cache_dir: Path | None = None,
         change_tracking_modes: list[str] | None = None,
+        expand_iframes: str = "same-origin",
     ) -> AsyncGenerator[CrawlEvent, None]:
         """Crawl a website, yielding events as pages complete.
 
@@ -108,6 +109,9 @@ class CrawlService:
                 changeTracking format is requested.
             change_tracking_modes: Optional diff modes for change tracking.
                 Supports: ["git-diff", "json"]. Passed to per-page scrape calls.
+            expand_iframes: Iframe expansion mode. "none" strips all (legacy),
+                "same-origin" expands same-origin iframes (default),
+                "all" expands all non-blocked iframes.
 
         Yields:
             CrawlEvent for each page and progress update
@@ -142,6 +146,7 @@ class CrawlService:
                     concurrency=concurrency,
                     wait_until=wait_until,
                     change_tracking_modes=change_tracking_modes,
+                    expand_iframes=expand_iframes,
                 ):
                     yield event
             else:
@@ -177,6 +182,7 @@ class CrawlService:
                         concurrency=concurrency,
                         wait_until=wait_until,
                         change_tracking_modes=change_tracking_modes,
+                        expand_iframes=expand_iframes,
                     ):
                         yield event
 
@@ -201,6 +207,7 @@ class CrawlService:
         concurrency: int,
         wait_until: WaitUntilType | None,
         change_tracking_modes: list[str] | None = None,
+        expand_iframes: str = "same-origin",
     ) -> AsyncGenerator[CrawlEvent, None]:
         """Core crawl logic. Assumes _browser, _map_service, _scrape_service are set."""
         assert self._map_service is not None
@@ -311,6 +318,7 @@ class CrawlService:
                     url_to_scrape,
                     formats=scrape_formats,  # type: ignore[arg-type]
                     change_tracking_modes=change_tracking_modes,
+                    expand_iframes=expand_iframes,  # type: ignore[arg-type]
                 )
 
                 if result.success and result.data:

--- a/src/supacrawl/services/crawl.py
+++ b/src/supacrawl/services/crawl.py
@@ -147,6 +147,7 @@ class CrawlService:
                     wait_until=wait_until,
                     change_tracking_modes=change_tracking_modes,
                     expand_iframes=expand_iframes,
+                    engine=engine,
                 ):
                     yield event
             else:
@@ -208,6 +209,7 @@ class CrawlService:
         wait_until: WaitUntilType | None,
         change_tracking_modes: list[str] | None = None,
         expand_iframes: str = "same-origin",
+        engine: str | None = None,
     ) -> AsyncGenerator[CrawlEvent, None]:
         """Core crawl logic. Assumes _browser, _map_service, _scrape_service are set."""
         assert self._map_service is not None
@@ -319,6 +321,7 @@ class CrawlService:
                     formats=scrape_formats,  # type: ignore[arg-type]
                     change_tracking_modes=change_tracking_modes,
                     expand_iframes=expand_iframes,  # type: ignore[arg-type]
+                    engine=engine,
                 )
 
                 if result.success and result.data:

--- a/src/supacrawl/services/crawl.py
+++ b/src/supacrawl/services/crawl.py
@@ -72,6 +72,8 @@ class CrawlService:
         wait_until: WaitUntilType | None = None,
         headless: bool | None = None,
         engine: str | None = None,
+        cache_dir: Path | None = None,
+        change_tracking_modes: list[str] | None = None,
     ) -> AsyncGenerator[CrawlEvent, None]:
         """Crawl a website, yielding events as pages complete.
 
@@ -102,6 +104,10 @@ class CrawlService:
                 creates its own BrowserManager (i.e. no injected browser).
             engine: Browser engine ("playwright", "patchright", "camoufox").
                 Overrides the stealth flag when set.
+            cache_dir: Cache directory for change tracking. Auto-resolved when
+                changeTracking format is requested.
+            change_tracking_modes: Optional diff modes for change tracking.
+                Supports: ["git-diff", "json"]. Passed to per-page scrape calls.
 
         Yields:
             CrawlEvent for each page and progress update
@@ -121,6 +127,7 @@ class CrawlService:
                 self._scrape_service = self._injected_scrape_service or ScrapeService(
                     browser=self._browser,
                     locale_config=locale_config,
+                    cache_dir=cache_dir,
                 )
                 async for event in self._crawl_inner(
                     url=url,
@@ -134,6 +141,7 @@ class CrawlService:
                     allow_external_links=allow_external_links,
                     concurrency=concurrency,
                     wait_until=wait_until,
+                    change_tracking_modes=change_tracking_modes,
                 ):
                     yield event
             else:
@@ -154,6 +162,7 @@ class CrawlService:
                     self._scrape_service = ScrapeService(
                         browser=browser,
                         locale_config=locale_config,
+                        cache_dir=cache_dir,
                     )
                     async for event in self._crawl_inner(
                         url=url,
@@ -167,6 +176,7 @@ class CrawlService:
                         allow_external_links=allow_external_links,
                         concurrency=concurrency,
                         wait_until=wait_until,
+                        change_tracking_modes=change_tracking_modes,
                     ):
                         yield event
 
@@ -190,6 +200,7 @@ class CrawlService:
         allow_external_links: bool,
         concurrency: int,
         wait_until: WaitUntilType | None,
+        change_tracking_modes: list[str] | None = None,
     ) -> AsyncGenerator[CrawlEvent, None]:
         """Core crawl logic. Assumes _browser, _map_service, _scrape_service are set."""
         assert self._map_service is not None
@@ -278,24 +289,36 @@ class CrawlService:
         # Scrape each URL
         completed = 0
         errors = []
+        wants_change_tracking = "changeTracking" in self._formats
+
+        # Track change statuses for crawl-level summary
+        change_counts: dict[str, int] = {"new": 0, "same": 0, "changed": 0, "removed": 0}
 
         for url_to_scrape in urls_to_scrape:
             try:
                 # Map output formats to scrape formats
-                scrape_formats = []
+                scrape_formats: list[str] = []
                 if "markdown" in self._formats or "json" in self._formats:
                     scrape_formats.append("markdown")
                 if "html" in self._formats or "json" in self._formats:
                     scrape_formats.append("html")
+                if wants_change_tracking:
+                    scrape_formats.append("changeTracking")
                 if not scrape_formats:
                     scrape_formats = ["markdown"]
 
                 result = await self._scrape_service.scrape(
                     url_to_scrape,
                     formats=scrape_formats,  # type: ignore[arg-type]
+                    change_tracking_modes=change_tracking_modes,
                 )
 
                 if result.success and result.data:
+                    # Track change status
+                    if result.data.change_tracking:
+                        status = result.data.change_tracking.change_status
+                        change_counts[status] = change_counts.get(status, 0) + 1
+
                     # Save to output directory
                     if output_dir:
                         self._save_page(output_dir, url_to_scrape, result.data)
@@ -308,6 +331,11 @@ class CrawlService:
                         total=total,
                     )
                 else:
+                    # Track "removed" if change tracking returned it
+                    if result.data and result.data.change_tracking:
+                        status = result.data.change_tracking.change_status
+                        change_counts[status] = change_counts.get(status, 0) + 1
+
                     errors.append(f"{url_to_scrape}: {result.error}")
                     yield CrawlEvent(
                         type="error",
@@ -336,11 +364,17 @@ class CrawlService:
                 total=total,
             )
 
+        # Build change summary if tracking was active
+        change_summary = None
+        if wants_change_tracking:
+            change_summary = {k: v for k, v in change_counts.items() if v > 0}
+
         # Final complete event
         yield CrawlEvent(
             type="complete",
             completed=completed,
             total=total,
+            change_summary=change_summary,
         )
 
     def _matches_patterns(self, url: str, patterns: list[str]) -> bool:

--- a/src/supacrawl/services/map.py
+++ b/src/supacrawl/services/map.py
@@ -51,24 +51,29 @@ class MapService:
         concurrency: int = DEFAULT_CONCURRENCY,
         wait_until: WaitUntilType | None = None,
         headless: bool | None = None,
+        engine: str | None = None,
     ):
         """Initialize map service.
 
         Args:
             browser: Optional BrowserManager (created if not provided)
-            stealth: Enable stealth mode via Patchright for anti-bot evasion
+            stealth: Enable stealth mode via Patchright for anti-bot evasion.
+                Ignored when engine is explicitly set.
             proxy: Proxy URL (e.g., http://user:pass@host:port, socks5://host:port)
             concurrency: Max concurrent requests for URL processing (default: 10)
             wait_until: Page load strategy. Options: commit, domcontentloaded (default),
                 load, networkidle. Falls back to SUPACRAWL_WAIT_UNTIL env var if None.
             headless: Run browser in headless mode. Passed through to any BrowserManager
                 instances created internally when no shared browser is provided.
+            engine: Browser engine ("playwright", "patchright", "camoufox").
+                Overrides the stealth flag when set.
         """
         self._browser = browser
         self._owns_browser = browser is None
         self._stealth = stealth
         self._proxy = proxy
         self._headless = headless
+        self._engine = engine
         self._concurrency = max(1, concurrency)  # Ensure at least 1
         self._wait_until = wait_until
 
@@ -369,7 +374,9 @@ class MapService:
         browser = self._browser
         close_browser = False
         if browser is None:
-            browser = BrowserManager(headless=self._headless, stealth=self._stealth, proxy=self._proxy)
+            browser = BrowserManager(
+                headless=self._headless, stealth=self._stealth, proxy=self._proxy, engine=self._engine
+            )
             close_browser = True
 
         # Semaphore for concurrent link extraction
@@ -475,7 +482,9 @@ class MapService:
         browser = self._browser
         close_browser = False
         if browser is None:
-            browser = BrowserManager(headless=self._headless, stealth=self._stealth, proxy=self._proxy)
+            browser = BrowserManager(
+                headless=self._headless, stealth=self._stealth, proxy=self._proxy, engine=self._engine
+            )
             close_browser = True
 
         try:

--- a/src/supacrawl/services/pdf.py
+++ b/src/supacrawl/services/pdf.py
@@ -1,0 +1,575 @@
+"""PDF parsing service for text extraction and OCR fallback.
+
+Provides three parsing modes:
+- fast: Pure text extraction only (pdfplumber)
+- auto: Text extraction first, OCR fallback if result is empty/short
+- ocr: Force full OCR processing (requires supacrawl[pdf-ocr] extra)
+
+PDF URLs are auto-detected by file extension (.pdf) or Content-Type header.
+When detected, the PDF is downloaded directly via httpx (bypassing the browser)
+and processed through the appropriate extraction pipeline.
+"""
+
+import io
+import logging
+import re
+from dataclasses import dataclass, field
+from typing import Literal
+from urllib.parse import urlparse
+
+import httpx
+
+LOGGER = logging.getLogger(__name__)
+
+# Magic bytes for PDF detection
+PDF_MAGIC = b"%PDF"
+PDF_SNIFF_SIZE = 1024
+
+# Minimum word count to consider text extraction successful (for auto mode fallback)
+MIN_WORDS_FOR_SUCCESS = 20
+
+# Maximum PDF file size in bytes (50 MB). Prevents memory exhaustion on huge files.
+MAX_PDF_SIZE = 50 * 1024 * 1024
+
+# Type alias for parse modes
+type ParsePdfMode = Literal["fast", "auto", "ocr"]
+
+
+@dataclass
+class PdfMetadata:
+    """Metadata extracted from PDF document properties."""
+
+    title: str | None = None
+    author: str | None = None
+    page_count: int = 0
+    creation_date: str | None = None
+
+
+@dataclass
+class PdfExtractionResult:
+    """Result of PDF text extraction."""
+
+    markdown: str
+    metadata: PdfMetadata = field(default_factory=PdfMetadata)
+
+
+# ---------------------------------------------------------------------------
+# Detection helpers
+# ---------------------------------------------------------------------------
+
+
+# Common web page extensions that are definitely NOT PDFs.
+# When a URL has one of these extensions, skip the HEAD request.
+_NON_PDF_EXTENSIONS = frozenset(
+    {
+        ".html",
+        ".htm",
+        ".php",
+        ".asp",
+        ".aspx",
+        ".jsp",
+        ".cgi",
+        ".shtml",
+        ".xhtml",
+        ".cfm",
+        ".pl",
+        ".py",
+        ".rb",
+        ".js",
+        ".css",
+        ".xml",
+        ".json",
+        ".rss",
+        ".atom",
+        ".svg",
+        ".txt",
+        ".png",
+        ".jpg",
+        ".jpeg",
+        ".gif",
+        ".webp",
+        ".ico",
+        ".bmp",
+        ".mp3",
+        ".mp4",
+        ".webm",
+        ".ogg",
+        ".wav",
+        ".avi",
+        ".mov",
+        ".zip",
+        ".tar",
+        ".gz",
+        ".bz2",
+        ".rar",
+        ".7z",
+    }
+)
+
+
+def is_pdf_url(url: str) -> bool:
+    """Check if URL path ends with .pdf extension.
+
+    Only inspects the URL path — does not make any network requests.
+    Query parameters and fragments are ignored.
+    """
+    path = urlparse(url).path.lower()
+    return path.endswith(".pdf")
+
+
+def _has_non_pdf_extension(url: str) -> bool:
+    """Check if URL has a known non-PDF file extension.
+
+    Used to skip the HEAD request for URLs that are clearly not PDFs.
+    """
+    path = urlparse(url).path.lower()
+    # Check if path ends with a known non-PDF extension
+    for ext in _NON_PDF_EXTENSIONS:
+        if path.endswith(ext):
+            return True
+    return False
+
+
+def needs_content_type_check(url: str) -> bool:
+    """Determine if a URL needs a HEAD request to check for PDF Content-Type.
+
+    Returns True only for ambiguous URLs (no extension or unknown extension).
+    URLs with known non-PDF extensions skip the check entirely.
+    """
+    if is_pdf_url(url):
+        return False  # Already detected as PDF
+    if _has_non_pdf_extension(url):
+        return False  # Known non-PDF extension
+    return True  # Ambiguous — needs HEAD request
+
+
+async def detect_pdf_content_type(url: str, timeout: float = 10.0) -> bool:
+    """Send a HEAD request and check for ``application/pdf`` Content-Type.
+
+    Returns False on any network error rather than raising.
+    """
+    try:
+        async with httpx.AsyncClient(
+            timeout=timeout,
+            follow_redirects=True,
+            headers={"User-Agent": "Mozilla/5.0 (compatible; supacrawl)"},
+        ) as client:
+            response = await client.head(url)
+            content_type = response.headers.get("content-type", "")
+            return "application/pdf" in content_type.lower()
+    except Exception:
+        return False
+
+
+def is_pdf_bytes(data: bytes) -> bool:
+    """Check if data starts with the ``%PDF`` magic number."""
+    return PDF_MAGIC in data[:PDF_SNIFF_SIZE]
+
+
+# ---------------------------------------------------------------------------
+# Download
+# ---------------------------------------------------------------------------
+
+
+async def download_pdf(url: str, timeout: float = 120.0, max_size: int = MAX_PDF_SIZE) -> bytes:
+    """Download PDF content from *url* via httpx.
+
+    Uses a generous timeout since PDFs can be large. Enforces a size limit
+    to prevent memory exhaustion.
+
+    Raises:
+        httpx.HTTPStatusError: If the server returns a non-2xx status.
+        httpx.TimeoutException: If the request times out.
+        ValueError: If the PDF exceeds *max_size* bytes.
+    """
+    async with httpx.AsyncClient(
+        timeout=timeout,
+        follow_redirects=True,
+        headers={"User-Agent": "Mozilla/5.0 (compatible; supacrawl)"},
+    ) as client:
+        response = await client.get(url)
+        response.raise_for_status()
+
+        if len(response.content) > max_size:
+            size_mb = len(response.content) / (1024 * 1024)
+            limit_mb = max_size / (1024 * 1024)
+            raise ValueError(f"PDF is too large ({size_mb:.1f} MB, limit is {limit_mb:.0f} MB). URL: {url}")
+
+        return response.content
+
+
+# ---------------------------------------------------------------------------
+# Availability checks
+# ---------------------------------------------------------------------------
+
+
+def _is_pdfplumber_available() -> bool:
+    try:
+        import pdfplumber  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
+def _is_ocr_available() -> bool:
+    try:
+        import pdf2image  # noqa: F401
+        import pytesseract  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Text extraction (pdfplumber)
+# ---------------------------------------------------------------------------
+
+
+def _extract_pdf_metadata(pdf: "pdfplumber.PDF") -> PdfMetadata:  # type: ignore[name-defined]  # noqa: F821
+    """Extract metadata from an open pdfplumber PDF object."""
+    meta = pdf.metadata or {}
+
+    title = meta.get("Title") or meta.get("title")
+    author = meta.get("Author") or meta.get("author")
+    creation_date = meta.get("CreationDate") or meta.get("creation_date")
+
+    # Clean up pdfplumber date format (D:20240101120000Z -> 2024-01-01T12:00:00Z)
+    if creation_date and isinstance(creation_date, str):
+        creation_date = _normalise_pdf_date(creation_date)
+
+    return PdfMetadata(
+        title=title if isinstance(title, str) else None,
+        author=author if isinstance(author, str) else None,
+        page_count=len(pdf.pages),
+        creation_date=creation_date,
+    )
+
+
+def _normalise_pdf_date(raw: str) -> str | None:
+    """Normalise a PDF date string like ``D:20240101120000+00'00'`` to ISO 8601."""
+    # Strip leading D: prefix
+    cleaned = re.sub(r"^D:", "", raw.strip())
+    # Try to parse the common format: YYYYMMDDHHmmSS
+    match = re.match(r"(\d{4})(\d{2})(\d{2})(\d{2})?(\d{2})?(\d{2})?", cleaned)
+    if not match:
+        return raw  # Return as-is if we can't parse
+    year, month, day = match.group(1), match.group(2), match.group(3)
+    hour = match.group(4) or "00"
+    minute = match.group(5) or "00"
+    second = match.group(6) or "00"
+    return f"{year}-{month}-{day}T{hour}:{minute}:{second}Z"
+
+
+def _table_to_markdown(table: list[list[str | None]]) -> str:
+    """Convert a pdfplumber table (2D list) to a markdown table.
+
+    Handles None cells and attempts to create a clean markdown table
+    with proper alignment separators.
+    """
+    if not table or not table[0]:
+        return ""
+
+    # Sanitise cells: replace None with empty string, strip whitespace
+    rows = [[_clean_cell(cell) for cell in row] for row in table]
+
+    # Use first row as header
+    header = rows[0]
+    col_count = len(header)
+
+    # Ensure all rows have the same column count
+    rows = [row + [""] * (col_count - len(row)) if len(row) < col_count else row[:col_count] for row in rows]
+
+    lines = []
+    # Header row
+    lines.append("| " + " | ".join(rows[0]) + " |")
+    # Separator
+    lines.append("| " + " | ".join("---" for _ in range(col_count)) + " |")
+    # Data rows
+    for row in rows[1:]:
+        lines.append("| " + " | ".join(row) + " |")
+
+    return "\n".join(lines)
+
+
+def _clean_cell(cell: str | None) -> str:
+    """Clean a table cell value for markdown output."""
+    if cell is None:
+        return ""
+    # Replace newlines within cells with spaces
+    text = str(cell).replace("\n", " ").strip()
+    # Escape pipe characters
+    text = text.replace("|", "\\|")
+    return text
+
+
+def _detect_headings(page: "pdfplumber.Page") -> dict[int, int]:  # type: ignore[name-defined]  # noqa: F821
+    """Detect heading lines based on font size heuristics.
+
+    Examines character-level data to find lines with notably larger font sizes.
+    Returns a mapping of line-start y-position → heading level (1-3).
+    """
+    chars = page.chars
+    if not chars:
+        return {}
+
+    # Collect font sizes
+    sizes: list[float] = []
+    for char in chars:
+        size = char.get("size", 0)
+        if size > 0:
+            sizes.append(size)
+
+    if not sizes:
+        return {}
+
+    # Find the most common font size (body text)
+    from collections import Counter
+
+    size_counts = Counter(round(s, 1) for s in sizes)
+    body_size = size_counts.most_common(1)[0][0]
+
+    # Group chars by approximate y-position (top) to identify lines
+    line_sizes: dict[int, list[float]] = {}
+    for char in chars:
+        y_key = round(char.get("top", 0))
+        size = char.get("size", 0)
+        if size > 0:
+            line_sizes.setdefault(y_key, []).append(size)
+
+    headings: dict[int, int] = {}
+    for y_pos, char_sizes in line_sizes.items():
+        avg_size = sum(char_sizes) / len(char_sizes)
+        ratio = avg_size / body_size if body_size > 0 else 1.0
+
+        if ratio >= 1.8:
+            headings[y_pos] = 1  # h1
+        elif ratio >= 1.4:
+            headings[y_pos] = 2  # h2
+        elif ratio >= 1.15:
+            headings[y_pos] = 3  # h3
+
+    return headings
+
+
+def _apply_headings_to_text(text: str, page: "pdfplumber.Page") -> str:  # type: ignore[name-defined]  # noqa: F821
+    """Apply heading markers to extracted text based on font size analysis.
+
+    This is best-effort: if heading detection fails, the original text is returned.
+    """
+    headings = _detect_headings(page)
+    if not headings:
+        return text
+
+    # Build a set of heading text snippets from char data
+    # Group chars into lines by y-position
+    lines_by_y: dict[int, str] = {}
+    for char in page.chars:
+        y_key = round(char.get("top", 0))
+        lines_by_y.setdefault(y_key, "")
+        char_text = char.get("text", "")
+        if char_text:
+            lines_by_y[y_key] += char_text
+
+    # Map heading y-positions to their text content
+    heading_texts: dict[str, int] = {}
+    for y_pos, level in headings.items():
+        line_text = lines_by_y.get(y_pos, "").strip()
+        if line_text and len(line_text) > 1:
+            heading_texts[line_text] = level
+
+    if not heading_texts:
+        return text
+
+    # Apply heading markers to the extracted text
+    lines = text.split("\n")
+    result = []
+    for line in lines:
+        stripped = line.strip()
+        if stripped in heading_texts:
+            level = heading_texts[stripped]
+            prefix = "#" * level
+            result.append(f"{prefix} {stripped}")
+        else:
+            result.append(line)
+
+    return "\n".join(result)
+
+
+def extract_text(pdf_bytes: bytes) -> PdfExtractionResult:
+    """Extract text and tables from a PDF using pdfplumber.
+
+    Returns markdown with:
+    - Text content from each page
+    - Tables converted to markdown tables
+    - Headings detected by font size heuristics
+    - PDF metadata (title, author, page count, creation date)
+
+    Raises:
+        ImportError: If pdfplumber is not installed.
+    """
+    import pdfplumber
+
+    pages_markdown: list[str] = []
+
+    with pdfplumber.open(io.BytesIO(pdf_bytes)) as pdf:
+        metadata = _extract_pdf_metadata(pdf)
+
+        for page in pdf.pages:
+            page_parts: list[str] = []
+
+            # Extract tables from this page
+            tables = page.extract_tables()
+            table_bboxes: list[tuple[float, float, float, float]] = []
+
+            if tables:
+                # Get table bounding boxes to exclude table regions from text
+                for table_obj in page.find_tables():
+                    table_bboxes.append(table_obj.bbox)
+
+            # Extract text, optionally cropping out table regions
+            if table_bboxes:
+                # Simple approach: extract full text, then append tables separately
+                text = page.extract_text() or ""
+                text = _apply_headings_to_text(text, page)
+                page_parts.append(text)
+
+                # Append tables as markdown
+                for table_data in tables:
+                    md_table = _table_to_markdown(table_data)
+                    if md_table:
+                        page_parts.append(md_table)
+            else:
+                text = page.extract_text() or ""
+                text = _apply_headings_to_text(text, page)
+                page_parts.append(text)
+
+            combined = "\n\n".join(part for part in page_parts if part.strip())
+            if combined.strip():
+                pages_markdown.append(combined)
+
+    # Join pages with horizontal rule separators for multi-page documents
+    if len(pages_markdown) > 1:
+        markdown = "\n\n---\n\n".join(pages_markdown)
+    else:
+        markdown = pages_markdown[0] if pages_markdown else ""
+
+    # Add document title as h1 if available and not already in content
+    if metadata.title and not markdown.startswith(f"# {metadata.title}"):
+        markdown = f"# {metadata.title}\n\n{markdown}"
+
+    return PdfExtractionResult(markdown=markdown, metadata=metadata)
+
+
+# ---------------------------------------------------------------------------
+# OCR extraction (pytesseract + pdf2image)
+# ---------------------------------------------------------------------------
+
+
+def extract_ocr(pdf_bytes: bytes) -> PdfExtractionResult:
+    """Extract text from a PDF using OCR (pytesseract + pdf2image).
+
+    Converts each page to an image and runs Tesseract OCR on it.
+    Best for scanned documents and image-only PDFs.
+
+    Raises:
+        ImportError: If pytesseract or pdf2image are not installed.
+        RuntimeError: If Tesseract is not installed on the system.
+    """
+    import pdf2image
+    import pytesseract
+
+    pages_text: list[str] = []
+
+    # Convert PDF to images
+    images = pdf2image.convert_from_bytes(pdf_bytes)
+    page_count = len(images)
+
+    for image in images:
+        text = pytesseract.image_to_string(image)
+        if text.strip():
+            pages_text.append(text.strip())
+
+    if len(pages_text) > 1:
+        markdown = "\n\n---\n\n".join(pages_text)
+    else:
+        markdown = pages_text[0] if pages_text else ""
+
+    # Try to get metadata from text extraction (OCR doesn't provide it)
+    metadata = PdfMetadata(page_count=page_count)
+    if _is_pdfplumber_available():
+        try:
+            import pdfplumber
+
+            with pdfplumber.open(io.BytesIO(pdf_bytes)) as pdf:
+                metadata = _extract_pdf_metadata(pdf)
+        except Exception:
+            pass  # Fall back to basic metadata
+
+    return PdfExtractionResult(markdown=markdown, metadata=metadata)
+
+
+# ---------------------------------------------------------------------------
+# Main parse orchestrator
+# ---------------------------------------------------------------------------
+
+
+async def parse_pdf(
+    url: str,
+    mode: ParsePdfMode = "auto",
+    pdf_bytes: bytes | None = None,
+) -> PdfExtractionResult:
+    """Parse a PDF document and extract text as markdown.
+
+    Args:
+        url: URL of the PDF (used for downloading if pdf_bytes not provided).
+        mode: Parsing mode — "fast" (text only), "auto" (text with OCR fallback),
+              or "ocr" (force OCR).
+        pdf_bytes: Pre-downloaded PDF content. If None, downloads from url.
+
+    Returns:
+        PdfExtractionResult with markdown content and metadata.
+
+    Raises:
+        ImportError: If required libraries are not installed.
+        ValueError: If the downloaded content is not a valid PDF.
+    """
+    # Download if not provided
+    if pdf_bytes is None:
+        LOGGER.info(f"Downloading PDF from {url}")
+        pdf_bytes = await download_pdf(url)
+
+    # Validate PDF content
+    if not is_pdf_bytes(pdf_bytes):
+        raise ValueError(f"Content from {url} is not a valid PDF (missing %PDF header)")
+
+    if mode == "ocr":
+        if not _is_ocr_available():
+            raise ImportError(
+                "OCR mode requires pytesseract and pdf2image. Install with: pip install supacrawl[pdf-ocr]"
+            )
+        LOGGER.info(f"Extracting text from PDF via OCR: {url}")
+        return extract_ocr(pdf_bytes)
+
+    # fast or auto: try text extraction first
+    if not _is_pdfplumber_available():
+        raise ImportError("PDF text extraction requires pdfplumber. Install with: pip install pdfplumber")
+
+    LOGGER.info(f"Extracting text from PDF: {url}")
+    result = extract_text(pdf_bytes)
+
+    # auto mode: check if text extraction was sufficient
+    if mode == "auto":
+        word_count = len(result.markdown.split())
+        if word_count < MIN_WORDS_FOR_SUCCESS:
+            if _is_ocr_available():
+                LOGGER.info(f"Text extraction yielded only {word_count} words, falling back to OCR: {url}")
+                return extract_ocr(pdf_bytes)
+            else:
+                LOGGER.warning(
+                    f"Text extraction yielded only {word_count} words for {url}. "
+                    "OCR fallback not available. Install with: pip install supacrawl[pdf-ocr]"
+                )
+
+    return result

--- a/src/supacrawl/services/scrape.py
+++ b/src/supacrawl/services/scrape.py
@@ -666,6 +666,23 @@ class ScrapeService:
                         change_tracking_modes=change_tracking_modes,
                     )
 
+                    # JSON comparison mode: extract structured data from both
+                    # versions and compare field-by-field
+                    if (
+                        change_tracking.change_status == "changed"
+                        and change_tracking_modes
+                        and "json" in change_tracking_modes
+                    ):
+                        json_comparison = await self._generate_json_comparison(
+                            previous_entry=previous_entry,
+                            current_markdown=markdown,
+                            current_json=json_data,
+                            json_schema=json_schema,
+                            json_prompt=json_prompt,
+                        )
+                        if json_comparison:
+                            change_tracking.json_changes = json_comparison
+
                 result = ScrapeResult(
                     success=True,
                     data=ScrapeData(  # type: ignore[call-arg]
@@ -949,6 +966,70 @@ class ScrapeService:
             return None
         finally:
             await client.close()
+
+    async def _generate_json_comparison(
+        self,
+        previous_entry: Any,
+        current_markdown: str | None,
+        current_json: dict[str, Any] | None,
+        json_schema: dict[str, Any] | None,
+        json_prompt: str | None,
+    ) -> dict[str, Any] | None:
+        """Compare structured JSON fields between previous and current versions.
+
+        Extracts JSON from both previous cached markdown and current markdown
+        using the LLM, then returns a field-level comparison of changed values.
+
+        Args:
+            previous_entry: Previous CacheEntry with cached response.
+            current_markdown: Current markdown content.
+            current_json: Already-extracted JSON from current content (avoids
+                redundant LLM call when ``json`` is also in formats).
+            json_schema: JSON schema for extraction.
+            json_prompt: Custom prompt for extraction.
+
+        Returns:
+            Dict mapping field names to ``{previous, current}`` values for
+            fields that differ, or None if comparison is not possible.
+        """
+        # Extract previous markdown from cached response
+        try:
+            prev_data = previous_entry.response.get("data", {})
+            prev_markdown = prev_data.get("markdown") or ""
+        except (AttributeError, TypeError):
+            LOGGER.warning("Cannot extract previous markdown for JSON comparison")
+            return None
+
+        if not prev_markdown:
+            return None
+
+        # Extract JSON from previous version
+        prev_json = await self._extract_json(prev_markdown, json_schema, json_prompt)
+
+        # Extract JSON from current version (reuse if already extracted)
+        curr_json = current_json
+        if curr_json is None:
+            curr_json = await self._extract_json(current_markdown or "", json_schema, json_prompt)
+
+        if not prev_json and not curr_json:
+            LOGGER.warning("JSON extraction returned no data for either version")
+            return None
+
+        # Compare field by field — only include fields that differ
+        all_keys: set[str] = set()
+        if prev_json:
+            all_keys.update(prev_json.keys())
+        if curr_json:
+            all_keys.update(curr_json.keys())
+
+        changes: dict[str, Any] = {}
+        for key in sorted(all_keys):
+            prev_val = prev_json.get(key) if prev_json else None
+            curr_val = curr_json.get(key) if curr_json else None
+            if prev_val != curr_val:
+                changes[key] = {"previous": prev_val, "current": curr_val}
+
+        return changes if changes else None
 
     def _process_action_results(
         self,

--- a/src/supacrawl/services/scrape.py
+++ b/src/supacrawl/services/scrape.py
@@ -409,6 +409,7 @@ class ScrapeService:
         wait_until: WaitUntilType | None = None,
         change_tracking_modes: list[str] | None = None,
         expand_iframes: Literal["none", "same-origin", "all"] = "same-origin",
+        device: str | None = None,
     ) -> ScrapeResult:
         """Scrape a URL and return content.
 
@@ -438,6 +439,9 @@ class ScrapeService:
             expand_iframes: Iframe expansion mode. "none" strips all (legacy),
                     "same-origin" expands same-origin iframes inline (default),
                     "all" expands all non-blocked iframes including cross-origin.
+            device: Playwright device name for mobile emulation (e.g. "iPhone 14",
+                    "Pixel 7"). Sets viewport, user agent, device scale factor, and
+                    touch support. Use ``--mobile`` as a shortcut for a default device.
 
         Returns:
             ScrapeResult with scraped content
@@ -449,12 +453,15 @@ class ScrapeService:
         if wants_change_tracking and "markdown" not in formats:
             formats = [*formats, "markdown"]
 
-        # Build cache variant for screenshot settings that affect output.
-        # Different screenshot_full_page values produce different images, so
-        # they must map to separate cache entries.
-        cache_variant: str | None = None
+        # Build cache variant for settings that affect output.
+        # Different settings produce different content, so they must map to
+        # separate cache entries.
+        variant_parts: list[str] = []
+        if device:
+            variant_parts.append(f"device={device}")
         if "screenshot" in formats and not screenshot_full_page:
-            cache_variant = "screenshot_full_page=False"
+            variant_parts.append("screenshot_full_page=False")
+        cache_variant: str | None = "|".join(variant_parts) if variant_parts else None
 
         # Get previous cached entry for change tracking comparison (ignores expiry)
         previous_entry = None
@@ -509,6 +516,7 @@ class ScrapeService:
                     actions=actions,
                     wait_until=wait_until,
                     expand_iframes=expand_iframes,
+                    device=device,
                 )
 
                 # Extract metadata
@@ -570,6 +578,7 @@ class ScrapeService:
                             wait_until=wait_until,
                             change_tracking_modes=change_tracking_modes,
                             expand_iframes=expand_iframes,
+                            device=device,
                         )
                     else:
                         LOGGER.warning(f"Bot detection suspected for {url}.{_stealth_hint()}")

--- a/src/supacrawl/services/scrape.py
+++ b/src/supacrawl/services/scrape.py
@@ -22,6 +22,7 @@ CAPTCHA Solving (optional, requires third-party service):
 import base64
 import logging
 import re
+from collections.abc import Sequence
 from pathlib import Path
 from typing import Any, Literal
 
@@ -410,6 +411,7 @@ class ScrapeService:
         change_tracking_modes: list[str] | None = None,
         expand_iframes: Literal["none", "same-origin", "all"] = "same-origin",
         device: str | None = None,
+        parse_pdf: Literal["fast", "auto", "ocr"] | None = "auto",
     ) -> ScrapeResult:
         """Scrape a URL and return content.
 
@@ -442,6 +444,9 @@ class ScrapeService:
             device: Playwright device name for mobile emulation (e.g. "iPhone 14",
                     "Pixel 7"). Sets viewport, user agent, device scale factor, and
                     touch support. Use ``--mobile`` as a shortcut for a default device.
+            parse_pdf: PDF parsing mode. "auto" (default) auto-detects PDF URLs and
+                    extracts text, falling back to OCR if available. "fast" uses text
+                    extraction only. "ocr" forces OCR. None disables PDF parsing.
 
         Returns:
             ScrapeResult with scraped content
@@ -479,6 +484,30 @@ class ScrapeService:
                 if result.data and result.data.metadata:
                     result.data.metadata.cache_hit = True
                 return result
+
+        # PDF detection: if parse_pdf is enabled, check if URL points to a PDF
+        # and route to the PDF extraction pipeline instead of the browser.
+        if parse_pdf is not None:
+            from supacrawl.services.pdf import detect_pdf_content_type, is_pdf_url, needs_content_type_check
+
+            is_pdf = is_pdf_url(url)
+            # Only send HEAD request for ambiguous URLs (no extension or unknown extension)
+            if not is_pdf and needs_content_type_check(url):
+                is_pdf = await detect_pdf_content_type(url)
+
+            if is_pdf:
+                return await self._scrape_pdf(
+                    url=url,
+                    mode=parse_pdf,
+                    formats=formats,
+                    json_schema=json_schema,
+                    json_prompt=json_prompt,
+                    max_age=max_age,
+                    cache_variant=cache_variant,
+                    wants_change_tracking=wants_change_tracking,
+                    previous_entry=previous_entry,
+                    change_tracking_modes=change_tracking_modes,
+                )
 
         try:
             # Create browser if needed
@@ -579,6 +608,7 @@ class ScrapeService:
                             change_tracking_modes=change_tracking_modes,
                             expand_iframes=expand_iframes,
                             device=device,
+                            parse_pdf=parse_pdf,
                         )
                     else:
                         LOGGER.warning(f"Bot detection suspected for {url}.{_stealth_hint()}")
@@ -791,6 +821,96 @@ class ScrapeService:
                 success=False,
                 error=error_msg,
             )
+
+    async def _scrape_pdf(
+        self,
+        url: str,
+        mode: Literal["fast", "auto", "ocr"],
+        formats: Sequence[str],
+        json_schema: dict[str, Any] | None = None,
+        json_prompt: str | None = None,
+        max_age: int = 0,
+        cache_variant: str | None = None,
+        wants_change_tracking: bool = False,
+        previous_entry: Any | None = None,
+        change_tracking_modes: list[str] | None = None,
+    ) -> ScrapeResult:
+        """Scrape a PDF URL by downloading and extracting text.
+
+        Bypasses the browser entirely — downloads the PDF via httpx and
+        processes it through the PDF extraction pipeline.
+        """
+        from supacrawl.services.pdf import parse_pdf as do_parse_pdf
+
+        try:
+            pdf_result = await do_parse_pdf(url=url, mode=mode)
+        except ImportError as e:
+            return ScrapeResult(success=False, error=str(e))
+        except Exception as e:
+            LOGGER.error(f"PDF extraction failed for {url}: {e}", exc_info=True)
+            return ScrapeResult(success=False, error=f"PDF extraction failed: {e}")
+
+        markdown = pdf_result.markdown
+        word_count = len(markdown.split()) if markdown else None
+
+        # LLM-powered features on extracted markdown
+        json_data = None
+        summary = None
+
+        if "json" in formats and markdown:
+            json_data = await self._extract_json(markdown, json_schema, json_prompt)
+
+        if "summary" in formats and markdown:
+            summary = await self._generate_summary(markdown)
+
+        # Build metadata from PDF properties
+        pdf_meta = pdf_result.metadata
+
+        # Change tracking
+        change_tracking = None
+        current_content_hash = None
+        if wants_change_tracking:
+            current_content_hash = _compute_content_hash(markdown)
+            change_tracking = _build_change_tracking(
+                previous_entry=previous_entry,
+                current_hash=current_content_hash,
+                current_markdown=markdown,
+                change_tracking_modes=change_tracking_modes,
+            )
+
+        result = ScrapeResult(
+            success=True,
+            data=ScrapeData(  # type: ignore[call-arg]
+                markdown=markdown if "markdown" in formats or "json" in formats or "summary" in formats else None,
+                metadata=ScrapeMetadata(
+                    title=pdf_meta.title,
+                    source_url=url,
+                    status_code=200,
+                    word_count=word_count,
+                    pdf_page_count=pdf_meta.page_count,
+                    pdf_author=pdf_meta.author,
+                    pdf_creation_date=pdf_meta.creation_date,
+                ),
+                llm_extraction=json_data,
+                summary=summary,
+                change_tracking=change_tracking,
+            ),
+        )
+
+        # Cache the result
+        effective_max_age = max_age
+        if wants_change_tracking and effective_max_age <= 0:
+            effective_max_age = 365 * 24 * 3600
+        if effective_max_age > 0 and self._cache:
+            self._cache.set(
+                url,
+                result.model_dump(),
+                effective_max_age,
+                variant=cache_variant,
+                content_hash=current_content_hash,
+            )
+
+        return result
 
     def _get_clean_html(
         self,

--- a/src/supacrawl/services/scrape.py
+++ b/src/supacrawl/services/scrape.py
@@ -444,9 +444,10 @@ class ScrapeService:
             device: Playwright device name for mobile emulation (e.g. "iPhone 14",
                     "Pixel 7"). Sets viewport, user agent, device scale factor, and
                     touch support. Use ``--mobile`` as a shortcut for a default device.
-            parse_pdf: PDF parsing mode. "auto" (default) auto-detects PDF URLs and
-                    extracts text, falling back to OCR if available. "fast" uses text
-                    extraction only. "ocr" forces OCR. None disables PDF parsing.
+            parse_pdf: PDF parsing mode. "auto" (default) detects PDF URLs by
+                    file extension (.pdf) and extracts text, falling back to OCR
+                    if available. "fast" uses text extraction only. "ocr" forces
+                    OCR. None disables PDF parsing entirely.
 
         Returns:
             ScrapeResult with scraped content
@@ -487,13 +488,12 @@ class ScrapeService:
 
         # PDF detection: if parse_pdf is enabled, check if URL points to a PDF
         # and route to the PDF extraction pipeline instead of the browser.
+        # Only checks the .pdf file extension — no HEAD requests are sent to
+        # avoid per-URL network overhead during bulk scraping.
         if parse_pdf is not None:
-            from supacrawl.services.pdf import detect_pdf_content_type, is_pdf_url, needs_content_type_check
+            from supacrawl.services.pdf import is_pdf_url
 
             is_pdf = is_pdf_url(url)
-            # Only send HEAD request for ambiguous URLs (no extension or unknown extension)
-            if not is_pdf and needs_content_type_check(url):
-                is_pdf = await detect_pdf_content_type(url)
 
             if is_pdf:
                 return await self._scrape_pdf(

--- a/src/supacrawl/services/scrape.py
+++ b/src/supacrawl/services/scrape.py
@@ -408,6 +408,7 @@ class ScrapeService:
         max_age: int = 0,
         wait_until: WaitUntilType | None = None,
         change_tracking_modes: list[str] | None = None,
+        expand_iframes: Literal["none", "same-origin", "all"] = "same-origin",
     ) -> ScrapeResult:
         """Scrape a URL and return content.
 
@@ -434,6 +435,9 @@ class ScrapeService:
                        load, networkidle. Falls back to SUPACRAWL_WAIT_UNTIL env var if None.
             change_tracking_modes: Optional diff modes for change tracking.
                     Supports: ["git-diff"]. Only used when "changeTracking" is in formats.
+            expand_iframes: Iframe expansion mode. "none" strips all (legacy),
+                    "same-origin" expands same-origin iframes inline (default),
+                    "all" expands all non-blocked iframes including cross-origin.
 
         Returns:
             ScrapeResult with scraped content
@@ -504,6 +508,7 @@ class ScrapeService:
                     screenshot_full_page=screenshot_full_page,
                     actions=actions,
                     wait_until=wait_until,
+                    expand_iframes=expand_iframes,
                 )
 
                 # Extract metadata
@@ -564,6 +569,7 @@ class ScrapeService:
                             max_age=max_age,
                             wait_until=wait_until,
                             change_tracking_modes=change_tracking_modes,
+                            expand_iframes=expand_iframes,
                         )
                     else:
                         LOGGER.warning(f"Bot detection suspected for {url}.{_stealth_hint()}")

--- a/src/supacrawl/services/scrape.py
+++ b/src/supacrawl/services/scrape.py
@@ -103,22 +103,39 @@ def _looks_like_bot_block(status_code: int, html: str, markdown: str | None) -> 
     return False
 
 
+def _is_camoufox_available() -> bool:
+    """Check if camoufox is installed for Tier 3 anti-detection."""
+    try:
+        import camoufox  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
 def _stealth_hint() -> str:
     """Return a hint about stealth mode based on availability.
 
     Returns a structured hint for both humans and LLM consumers.
     Basic stealth (fingerprint evasion) is always active.
-    This hint is for enhanced stealth via Patchright.
+    This hint covers both Patchright (Tier 2) and Camoufox (Tier 3).
     """
     if _is_patchright_available():
-        return (
+        hint = (
             " [HINT: Basic anti-bot evasion is already active. "
-            "For enhanced stealth, use --stealth flag or stealth=True]"
+            "For enhanced stealth, use --stealth flag or --engine patchright."
         )
+        if _is_camoufox_available():
+            hint += " For Akamai/advanced protection, use --engine camoufox."
+        hint += "]"
+        return hint
+    elif _is_camoufox_available():
+        return " [HINT: Basic anti-bot evasion is active. For Akamai/advanced protection, use --engine camoufox]"
     else:
         return (
             " [HINT: Basic anti-bot evasion is active but site may need enhanced stealth. "
-            "Install with: pip install supacrawl[stealth] then retry with --stealth]"
+            "Install with: pip install supacrawl[stealth] (Cloudflare) "
+            "or pip install supacrawl[camoufox] (Akamai)]"
         )
 
 
@@ -219,6 +236,7 @@ class ScrapeService:
         proxy: str | None = None,
         solve_captcha: bool = False,
         headless: bool | None = None,
+        engine: str | None = None,
     ):
         """Initialize scrape service.
 
@@ -227,12 +245,15 @@ class ScrapeService:
             converter: Optional MarkdownConverter (created if not provided)
             locale_config: Optional LocaleConfig for browser locale/timezone settings
             cache_dir: Optional cache directory (enables caching if provided)
-            stealth: Enable stealth mode via Patchright for anti-bot evasion
+            stealth: Enable stealth mode via Patchright for anti-bot evasion.
+                Ignored when engine is explicitly set.
             proxy: Proxy URL (e.g., http://user:pass@host:port, socks5://host:port)
             solve_captcha: Enable CAPTCHA solving via 2Captcha (requires pip install supacrawl[captcha]
                           and CAPTCHA_API_KEY environment variable). WARNING: Each solve costs ~$0.002-0.003.
             headless: Run browser in headless mode. Passed through to any BrowserManager
                 instances created internally (e.g. for CAPTCHA solving or standalone usage).
+            engine: Browser engine to use ("playwright", "patchright", "camoufox").
+                Overrides the stealth flag when set.
         """
         self._browser = browser
         self._converter = converter or MarkdownConverter()
@@ -242,6 +263,7 @@ class ScrapeService:
         self._proxy = proxy
         self._solve_captcha = solve_captcha
         self._headless = headless
+        self._engine = engine
         self._cache = CacheManager(cache_dir) if cache_dir else None
         self._captcha_solver: Any = None  # Lazy-loaded CaptchaSolver
 
@@ -324,6 +346,7 @@ class ScrapeService:
                     locale_config=self._locale_config,
                     stealth=self._stealth,
                     proxy=self._proxy,
+                    engine=self._engine,
                 )
                 await browser.__aenter__()
 
@@ -886,6 +909,7 @@ class ScrapeService:
             locale_config=self._locale_config,
             stealth=self._stealth,
             proxy=self._proxy,
+            engine=self._engine,
         )
 
         try:
@@ -894,8 +918,14 @@ class ScrapeService:
             # Navigate to page
             if browser._browser is None:
                 raise ProviderError("Browser failed to start", provider="playwright")
-            context = await browser._browser.new_context(**browser._build_context_options())
-            page = await context.new_page()
+
+            # Camoufox browser IS the context — don't create a separate one
+            if browser.engine == "camoufox":
+                context = None
+                page = await browser._browser.new_page()
+            else:
+                context = await browser._browser.new_context(**browser._build_context_options())
+                page = await context.new_page()
 
             try:
                 await page.goto(url, wait_until="domcontentloaded", timeout=timeout)

--- a/src/supacrawl/services/scrape.py
+++ b/src/supacrawl/services/scrape.py
@@ -421,7 +421,8 @@ class ScrapeService:
                      Supports: markdown, html, rawHtml, links, screenshot, pdf,
                      json, images, branding, summary, changeTracking
             only_main_content: Extract main content area only
-            wait_for: Additional wait time in ms after page load
+            wait_for: Additional wait time in ms after page load. When > 0,
+                     also enables SPA stability polling (DOM hash checking).
             timeout: Page load timeout in ms
             screenshot_full_page: Capture full scrollable page for screenshots
             actions: List of Action objects to execute before capturing content

--- a/src/supacrawl/services/scrape.py
+++ b/src/supacrawl/services/scrape.py
@@ -348,6 +348,7 @@ class ScrapeService:
         solve_captcha: bool = False,
         headless: bool | None = None,
         engine: str | None = None,
+        firefox_user_prefs: dict[str, Any] | None = None,
     ):
         """Initialize scrape service.
 
@@ -365,6 +366,9 @@ class ScrapeService:
                 instances created internally (e.g. for CAPTCHA solving or standalone usage).
             engine: Browser engine to use ("playwright", "patchright", "camoufox").
                 Overrides the stealth flag when set.
+            firefox_user_prefs: Firefox about:config preferences for Camoufox.
+                Only used when engine="camoufox" and browser is created internally.
+                Example: {"network.http.http2.enabled": False} to force HTTP/1.1.
         """
         self._browser = browser
         self._converter = converter or MarkdownConverter()
@@ -375,6 +379,7 @@ class ScrapeService:
         self._solve_captcha = solve_captcha
         self._headless = headless
         self._engine = engine
+        self._firefox_user_prefs = firefox_user_prefs
         self._cache = CacheManager(cache_dir) if cache_dir else None
         self._captcha_solver: Any = None  # Lazy-loaded CaptchaSolver
 
@@ -536,6 +541,7 @@ class ScrapeService:
                     stealth=self._stealth,
                     proxy=self._proxy,
                     engine=effective_engine,
+                    firefox_user_prefs=self._firefox_user_prefs,
                 )
                 await browser.__aenter__()
                 owns_browser = True
@@ -811,42 +817,89 @@ class ScrapeService:
             # Chromium-based browsers (Playwright/Patchright) can be rejected at the
             # TLS level by aggressive bot detection (e.g. Akamai). Camoufox uses
             # Firefox's TLS stack which has a different fingerprint.
-            if (
-                "ERR_HTTP2_PROTOCOL_ERROR" in error_msg
-                and self._engine != "camoufox"
-                and engine != "camoufox"
-                and _is_camoufox_available()
-            ):
-                LOGGER.info(f"HTTP/2 protocol error for {url}, retrying with Camoufox engine")
-                camoufox_service = ScrapeService(
-                    converter=self._converter,
-                    locale_config=self._locale_config,
-                    cache_dir=self._cache.cache_dir if self._cache else None,
-                    stealth=self._stealth,
-                    proxy=self._proxy,
-                    solve_captcha=self._solve_captcha,
-                    headless=self._headless,
-                    engine="camoufox",
-                )
-                return await camoufox_service.scrape(
-                    url=url,
-                    formats=formats,
-                    only_main_content=only_main_content,
-                    wait_for=wait_for,
-                    timeout=timeout,
-                    screenshot_full_page=screenshot_full_page,
-                    actions=actions,
-                    json_schema=json_schema,
-                    json_prompt=json_prompt,
-                    include_tags=include_tags,
-                    exclude_tags=exclude_tags,
-                    max_age=max_age,
-                    wait_until=wait_until,
-                    change_tracking_modes=change_tracking_modes,
-                    expand_iframes=expand_iframes,
-                    device=device,
-                    parse_pdf=parse_pdf,
-                )
+            #
+            # Two-stage fallback:
+            #   1. Chromium → Camoufox (different TLS fingerprint)
+            #   2. Camoufox → Camoufox with HTTP/2 disabled (forces HTTP/1.1)
+            #
+            # Stage 2 handles environments where even Firefox's TLS fingerprint
+            # is rejected over HTTP/2 (reported on some systems).
+            if "ERR_HTTP2_PROTOCOL_ERROR" in error_msg and _is_camoufox_available():
+                is_camoufox = self._engine == "camoufox" or engine == "camoufox"
+
+                if not is_camoufox:
+                    # Stage 1: Chromium failed → try Camoufox with standard HTTP/2
+                    LOGGER.info(
+                        "HTTP/2 protocol error for %s, retrying with Camoufox engine",
+                        url,
+                    )
+                    camoufox_service = ScrapeService(
+                        converter=self._converter,
+                        locale_config=self._locale_config,
+                        cache_dir=self._cache.cache_dir if self._cache else None,
+                        stealth=self._stealth,
+                        proxy=self._proxy,
+                        solve_captcha=self._solve_captcha,
+                        headless=self._headless,
+                        engine="camoufox",
+                    )
+                    return await camoufox_service.scrape(
+                        url=url,
+                        formats=formats,
+                        only_main_content=only_main_content,
+                        wait_for=wait_for,
+                        timeout=timeout,
+                        screenshot_full_page=screenshot_full_page,
+                        actions=actions,
+                        json_schema=json_schema,
+                        json_prompt=json_prompt,
+                        include_tags=include_tags,
+                        exclude_tags=exclude_tags,
+                        max_age=max_age,
+                        wait_until=wait_until,
+                        change_tracking_modes=change_tracking_modes,
+                        expand_iframes=expand_iframes,
+                        device=device,
+                        parse_pdf=parse_pdf,
+                    )
+
+                # Stage 2: Camoufox also failed → retry with HTTP/2 disabled.
+                # Guard: if we already have firefox_user_prefs set, don't recurse.
+                if not self._firefox_user_prefs:
+                    LOGGER.info(
+                        "HTTP/2 protocol error for %s with Camoufox, retrying with HTTP/2 disabled",
+                        url,
+                    )
+                    h1_service = ScrapeService(
+                        converter=self._converter,
+                        locale_config=self._locale_config,
+                        cache_dir=self._cache.cache_dir if self._cache else None,
+                        stealth=self._stealth,
+                        proxy=self._proxy,
+                        solve_captcha=self._solve_captcha,
+                        headless=self._headless,
+                        engine="camoufox",
+                        firefox_user_prefs={"network.http.http2.enabled": False},
+                    )
+                    return await h1_service.scrape(
+                        url=url,
+                        formats=formats,
+                        only_main_content=only_main_content,
+                        wait_for=wait_for,
+                        timeout=timeout,
+                        screenshot_full_page=screenshot_full_page,
+                        actions=actions,
+                        json_schema=json_schema,
+                        json_prompt=json_prompt,
+                        include_tags=include_tags,
+                        exclude_tags=exclude_tags,
+                        max_age=max_age,
+                        wait_until=wait_until,
+                        change_tracking_modes=change_tracking_modes,
+                        expand_iframes=expand_iframes,
+                        device=device,
+                        parse_pdf=parse_pdf,
+                    )
 
             # Add stealth hint for common bot-detection related errors
             if not self._stealth and any(

--- a/src/supacrawl/services/scrape.py
+++ b/src/supacrawl/services/scrape.py
@@ -807,9 +807,51 @@ class ScrapeService:
         except Exception as e:
             error_msg = str(e)
 
+            # Auto-retry with Camoufox on HTTP/2 protocol errors.
+            # Chromium-based browsers (Playwright/Patchright) can be rejected at the
+            # TLS level by aggressive bot detection (e.g. Akamai). Camoufox uses
+            # Firefox's TLS stack which has a different fingerprint.
+            if (
+                "ERR_HTTP2_PROTOCOL_ERROR" in error_msg
+                and self._engine != "camoufox"
+                and engine != "camoufox"
+                and _is_camoufox_available()
+            ):
+                LOGGER.info(f"HTTP/2 protocol error for {url}, retrying with Camoufox engine")
+                camoufox_service = ScrapeService(
+                    converter=self._converter,
+                    locale_config=self._locale_config,
+                    cache_dir=self._cache.cache_dir if self._cache else None,
+                    stealth=self._stealth,
+                    proxy=self._proxy,
+                    solve_captcha=self._solve_captcha,
+                    headless=self._headless,
+                    engine="camoufox",
+                )
+                return await camoufox_service.scrape(
+                    url=url,
+                    formats=formats,
+                    only_main_content=only_main_content,
+                    wait_for=wait_for,
+                    timeout=timeout,
+                    screenshot_full_page=screenshot_full_page,
+                    actions=actions,
+                    json_schema=json_schema,
+                    json_prompt=json_prompt,
+                    include_tags=include_tags,
+                    exclude_tags=exclude_tags,
+                    max_age=max_age,
+                    wait_until=wait_until,
+                    change_tracking_modes=change_tracking_modes,
+                    expand_iframes=expand_iframes,
+                    device=device,
+                    parse_pdf=parse_pdf,
+                )
+
             # Add stealth hint for common bot-detection related errors
             if not self._stealth and any(
-                pattern in error_msg.lower() for pattern in ["403", "429", "timeout", "blocked", "denied"]
+                pattern in error_msg.lower()
+                for pattern in ["403", "429", "timeout", "blocked", "denied", "err_http2_protocol_error"]
             ):
                 error_msg += _stealth_hint()
 

--- a/src/supacrawl/services/scrape.py
+++ b/src/supacrawl/services/scrape.py
@@ -412,6 +412,7 @@ class ScrapeService:
         expand_iframes: Literal["none", "same-origin", "all"] = "same-origin",
         device: str | None = None,
         parse_pdf: Literal["fast", "auto", "ocr"] | None = "auto",
+        engine: str | None = None,
     ) -> ScrapeResult:
         """Scrape a URL and return content.
 
@@ -449,6 +450,9 @@ class ScrapeService:
                     file extension (.pdf) and extracts text, falling back to OCR
                     if available. "fast" uses text extraction only. "ocr" forces
                     OCR. None disables PDF parsing entirely.
+            engine: Browser engine override for this request. When set and different
+                    from the service's default engine, a temporary browser is created.
+                    Options: "playwright", "patchright", "camoufox".
 
         Returns:
             ScrapeResult with scraped content
@@ -511,20 +515,30 @@ class ScrapeService:
                 )
 
         try:
-            # Create browser if needed
+            # Determine effective engine for this request
+            effective_engine = engine or self._engine
+
+            # Create browser if needed, or use a temporary one for engine override
             browser = self._browser
             owns_browser = self._owns_browser
 
-            if owns_browser:
+            # Per-request engine override: if the caller requested a different engine
+            # than the shared browser, create a temporary browser for this request.
+            needs_engine_override = (
+                engine is not None and not owns_browser and browser is not None and browser.engine != engine
+            )
+
+            if owns_browser or needs_engine_override:
                 browser = BrowserManager(
                     headless=self._headless,
                     timeout_ms=timeout,
                     locale_config=self._locale_config,
                     stealth=self._stealth,
                     proxy=self._proxy,
-                    engine=self._engine,
+                    engine=effective_engine,
                 )
                 await browser.__aenter__()
+                owns_browser = True
 
             # At this point browser is guaranteed to be set
             if browser is None:

--- a/src/supacrawl/services/scrape.py
+++ b/src/supacrawl/services/scrape.py
@@ -176,6 +176,116 @@ def _captcha_hint() -> str:
         )
 
 
+def _compute_content_hash(markdown: str | None) -> str:
+    """Compute SHA256 hash of markdown content for change tracking.
+
+    Args:
+        markdown: Markdown content to hash. None or empty string produces
+            a hash of the empty string.
+
+    Returns:
+        Hex-encoded SHA256 hash string.
+    """
+    import hashlib
+
+    content = (markdown or "").encode("utf-8")
+    return hashlib.sha256(content).hexdigest()
+
+
+def _build_change_tracking(
+    previous_entry: Any | None,
+    current_hash: str,
+    current_markdown: str | None,
+    change_tracking_modes: list[str] | None = None,
+) -> Any:
+    """Build change tracking data by comparing current scrape to cached previous.
+
+    Args:
+        previous_entry: Previous CacheEntry (from get_previous), or None.
+        current_hash: SHA256 hash of current markdown content.
+        current_markdown: Current markdown content (for diff generation).
+        change_tracking_modes: Optional list of diff modes (e.g. ["git-diff"]).
+
+    Returns:
+        ChangeTrackingData with change status and optional diff.
+    """
+    from supacrawl.models import ChangeTrackingData
+
+    if previous_entry is None:
+        return ChangeTrackingData(
+            change_status="new",
+            content_hash=current_hash,
+        )
+
+    previous_hash = previous_entry.content_hash
+    previous_scrape_at = previous_entry.cached_at
+
+    # Fast path: hash comparison
+    if previous_hash is not None and previous_hash == current_hash:
+        return ChangeTrackingData(
+            previous_scrape_at=previous_scrape_at,
+            change_status="same",
+            content_hash=current_hash,
+        )
+
+    # Content has changed (or no previous hash to compare — treat as changed)
+    diff = None
+    if change_tracking_modes and "git-diff" in change_tracking_modes:
+        diff = _generate_unified_diff(previous_entry, current_markdown)
+
+    return ChangeTrackingData(
+        previous_scrape_at=previous_scrape_at,
+        change_status="changed",
+        content_hash=current_hash,
+        diff=diff,
+    )
+
+
+def _generate_unified_diff(
+    previous_entry: Any,
+    current_markdown: str | None,
+) -> Any:
+    """Generate a unified diff between previous and current markdown.
+
+    Args:
+        previous_entry: Previous CacheEntry containing the cached response.
+        current_markdown: Current markdown content.
+
+    Returns:
+        ChangeTrackingDiff with unified diff text, or None if unable to diff.
+    """
+    import difflib
+
+    from supacrawl.models import ChangeTrackingDiff
+
+    # Extract previous markdown from cached response
+    prev_markdown = ""
+    try:
+        prev_data = previous_entry.response.get("data", {})
+        prev_markdown = prev_data.get("markdown") or ""
+    except (AttributeError, TypeError):
+        return None
+
+    curr_markdown = current_markdown or ""
+
+    prev_lines = prev_markdown.splitlines(keepends=True)
+    curr_lines = curr_markdown.splitlines(keepends=True)
+
+    diff_lines = list(
+        difflib.unified_diff(
+            prev_lines,
+            curr_lines,
+            fromfile="previous",
+            tofile="current",
+        )
+    )
+
+    if not diff_lines:
+        return None
+
+    return ChangeTrackingDiff(text="".join(diff_lines))
+
+
 class ScrapeService:
     """Scrape a single URL and extract content.
 
@@ -272,7 +382,17 @@ class ScrapeService:
         url: str,
         formats: list[
             Literal[
-                "markdown", "html", "rawHtml", "links", "screenshot", "pdf", "json", "images", "branding", "summary"
+                "markdown",
+                "html",
+                "rawHtml",
+                "links",
+                "screenshot",
+                "pdf",
+                "json",
+                "images",
+                "branding",
+                "summary",
+                "changeTracking",
             ]
         ]
         | None = None,
@@ -287,13 +407,15 @@ class ScrapeService:
         exclude_tags: list[str] | None = None,
         max_age: int = 0,
         wait_until: WaitUntilType | None = None,
+        change_tracking_modes: list[str] | None = None,
     ) -> ScrapeResult:
         """Scrape a URL and return content.
 
         Args:
             url: URL to scrape
             formats: Content formats to return (default: ["markdown"])
-                     Supports: markdown, html, rawHtml, links, screenshot, pdf, json, images, branding, summary
+                     Supports: markdown, html, rawHtml, links, screenshot, pdf,
+                     json, images, branding, summary, changeTracking
             only_main_content: Extract main content area only
             wait_for: Additional wait time in ms after page load
             timeout: Page load timeout in ms
@@ -310,11 +432,18 @@ class ScrapeService:
                     Returns cached content if available and fresh.
             wait_until: Page load strategy. Options: commit, domcontentloaded (default),
                        load, networkidle. Falls back to SUPACRAWL_WAIT_UNTIL env var if None.
+            change_tracking_modes: Optional diff modes for change tracking.
+                    Supports: ["git-diff"]. Only used when "changeTracking" is in formats.
 
         Returns:
             ScrapeResult with scraped content
         """
         formats = formats or ["markdown"]
+        wants_change_tracking = "changeTracking" in formats
+
+        # Change tracking requires markdown to compute content hash
+        if wants_change_tracking and "markdown" not in formats:
+            formats = [*formats, "markdown"]
 
         # Build cache variant for screenshot settings that affect output.
         # Different screenshot_full_page values produce different images, so
@@ -323,8 +452,14 @@ class ScrapeService:
         if "screenshot" in formats and not screenshot_full_page:
             cache_variant = "screenshot_full_page=False"
 
+        # Get previous cached entry for change tracking comparison (ignores expiry)
+        previous_entry = None
+        if wants_change_tracking and self._cache:
+            previous_entry = self._cache.get_previous(url, variant=cache_variant)
+
         # Check cache if max_age > 0 and cache is configured
-        if max_age > 0 and self._cache:
+        # When change tracking is requested, skip the cache shortcut — always do a fresh scrape
+        if max_age > 0 and self._cache and not wants_change_tracking:
             cached = self._cache.get(url, max_age, variant=cache_variant)
             if cached:
                 LOGGER.debug(f"Cache hit for {url}")
@@ -427,6 +562,8 @@ class ScrapeService:
                             include_tags=include_tags,
                             exclude_tags=exclude_tags,
                             max_age=max_age,
+                            wait_until=wait_until,
+                            change_tracking_modes=change_tracking_modes,
                         )
                     else:
                         LOGGER.warning(f"Bot detection suspected for {url}.{_stealth_hint()}")
@@ -517,6 +654,18 @@ class ScrapeService:
                     exclude_tags=exclude_tags,
                 )
 
+                # Compute change tracking if requested
+                change_tracking = None
+                current_content_hash = None
+                if wants_change_tracking:
+                    current_content_hash = _compute_content_hash(markdown)
+                    change_tracking = _build_change_tracking(
+                        previous_entry=previous_entry,
+                        current_hash=current_content_hash,
+                        current_markdown=markdown,
+                        change_tracking_modes=change_tracking_modes,
+                    )
+
                 result = ScrapeResult(
                     success=True,
                     data=ScrapeData(  # type: ignore[call-arg]
@@ -553,12 +702,24 @@ class ScrapeService:
                         images=images,
                         branding=branding,
                         actions=actions_output,
+                        change_tracking=change_tracking,
                     ),
                 )
 
                 # Store in cache if max_age > 0 and cache is configured
-                if max_age > 0 and self._cache:
-                    self._cache.set(url, result.model_dump(), max_age, variant=cache_variant)
+                # When change tracking is active, auto-enable caching so future
+                # comparisons have a previous version to diff against.
+                effective_max_age = max_age
+                if wants_change_tracking and effective_max_age <= 0:
+                    effective_max_age = 365 * 24 * 3600  # 1 year default for change tracking
+                if effective_max_age > 0 and self._cache:
+                    self._cache.set(
+                        url,
+                        result.model_dump(),
+                        effective_max_age,
+                        variant=cache_variant,
+                        content_hash=current_content_hash,
+                    )
 
                 return result
 
@@ -576,6 +737,24 @@ class ScrapeService:
                 error_msg += _stealth_hint()
 
             LOGGER.error(f"Scrape failed for {url}: {e}", exc_info=True)
+
+            # If change tracking is active and we have a previous version,
+            # report "removed" status (URL no longer accessible)
+            if wants_change_tracking and previous_entry is not None:
+                from supacrawl.models import ChangeTrackingData
+
+                return ScrapeResult(
+                    success=False,
+                    error=error_msg,
+                    data=ScrapeData(  # type: ignore[call-arg]
+                        metadata=ScrapeMetadata(source_url=url),
+                        change_tracking=ChangeTrackingData(
+                            previous_scrape_at=previous_entry.cached_at,
+                            change_status="removed",
+                        ),
+                    ),
+                )
+
             return ScrapeResult(
                 success=False,
                 error=error_msg,

--- a/src/supacrawl/services/scrape.py
+++ b/src/supacrawl/services/scrape.py
@@ -537,8 +537,8 @@ class ScrapeService:
                 # Fetch page with actions
                 page_content = await browser.fetch_page(
                     url,
-                    wait_for_spa=True,
-                    spa_timeout_ms=wait_for if wait_for > 0 else 5000,
+                    wait_for_spa=wait_for > 0,
+                    spa_timeout_ms=wait_for,
                     capture_screenshot=capture_screenshot,
                     capture_pdf=capture_pdf,
                     screenshot_full_page=screenshot_full_page,
@@ -658,7 +658,7 @@ class ScrapeService:
                     raw_html = page_content.html
 
                 if "links" in formats:
-                    links = await browser.extract_links(url)
+                    links = self._extract_links_from_html(page_content.html, url)
 
                 if "images" in formats:
                     images = await browser.extract_images(page_content.html, url)
@@ -911,6 +911,38 @@ class ScrapeService:
             )
 
         return result
+
+    @staticmethod
+    def _extract_links_from_html(html: str, base_url: str) -> list[str]:
+        """Extract absolute HTTP(S) links from already-fetched HTML.
+
+        Parses anchor tags from the rendered HTML instead of re-navigating
+        the browser, avoiding a full page re-fetch.
+
+        Args:
+            html: HTML content (post-JavaScript rendering, with iframes expanded)
+            base_url: Base URL for resolving relative hrefs
+
+        Returns:
+            List of absolute URLs starting with http(s)
+        """
+        from urllib.parse import urljoin, urlparse
+
+        soup = BeautifulSoup(html, "html.parser")
+        links: list[str] = []
+        for anchor in soup.find_all("a", href=True):
+            href = anchor["href"]
+            if isinstance(href, list):
+                href = href[0] if href else ""
+            if not href:
+                continue
+            # Resolve relative URLs
+            if not urlparse(href).netloc:
+                href = urljoin(base_url, href)
+            # Only include http(s) links (matches browser.extract_links behaviour)
+            if href.startswith("http"):
+                links.append(href)
+        return links
 
     def _get_clean_html(
         self,

--- a/src/supacrawl/services/search.py
+++ b/src/supacrawl/services/search.py
@@ -33,6 +33,13 @@ LOGGER = logging.getLogger(__name__)
 # Type alias for source types
 type SourceType = Literal["web", "images", "news"]
 
+# Browser-like User-Agent to avoid bot detection on search engines
+_SEARCH_USER_AGENT = (
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+    "AppleWebKit/537.36 (KHTML, like Gecko) "
+    "Chrome/131.0.0.0 Safari/537.36"
+)
+
 
 @dataclass
 class ScrapeOptions:
@@ -79,7 +86,7 @@ class SearchService:
         if self._http_client is None:
             self._http_client = httpx.AsyncClient(
                 timeout=30.0,
-                headers={"User-Agent": "Supacrawl/1.0"},
+                headers={"User-Agent": _SEARCH_USER_AGENT},
             )
         return self._http_client
 
@@ -206,6 +213,9 @@ class SearchService:
         Search using DuckDuckGo HTML interface.
 
         Uses DuckDuckGo Lite for simpler HTML parsing.
+
+        Raises:
+            ProviderError: If DuckDuckGo returns a CAPTCHA challenge.
         """
         client = await self._get_client()
 
@@ -214,6 +224,15 @@ class SearchService:
         response.raise_for_status()
 
         html = response.text
+
+        # Detect CAPTCHA/bot challenge: DDG returns HTTP 202 with an anomaly modal
+        if response.status_code == 202 or "anomaly-modal" in html:
+            raise ProviderError(
+                "DuckDuckGo returned a CAPTCHA challenge (bot detection). Search results are unavailable.",
+                provider="duckduckgo",
+                correlation_id=correlation_id,
+            )
+
         results = self._parse_ddg_results(html, limit)
 
         log_with_correlation(

--- a/tests/test_change_tracking.py
+++ b/tests/test_change_tracking.py
@@ -1,0 +1,242 @@
+"""Tests for change tracking feature."""
+
+from pathlib import Path
+
+from supacrawl.cache import CacheEntry, CacheManager
+from supacrawl.models import ChangeTrackingData, ChangeTrackingDiff, ScrapeData
+from supacrawl.services.scrape import (
+    _build_change_tracking,
+    _compute_content_hash,
+    _generate_unified_diff,
+)
+
+
+class TestComputeContentHash:
+    """Tests for _compute_content_hash."""
+
+    def test_hash_of_none(self):
+        result = _compute_content_hash(None)
+        assert isinstance(result, str)
+        assert len(result) == 64  # SHA256 hex digest
+
+    def test_hash_of_empty_string(self):
+        result = _compute_content_hash("")
+        assert result == _compute_content_hash(None)  # Both hash empty bytes
+
+    def test_hash_deterministic(self):
+        assert _compute_content_hash("hello") == _compute_content_hash("hello")
+
+    def test_hash_different_content(self):
+        assert _compute_content_hash("hello") != _compute_content_hash("world")
+
+    def test_hash_is_sha256(self):
+        import hashlib
+
+        expected = hashlib.sha256(b"test content").hexdigest()
+        assert _compute_content_hash("test content") == expected
+
+
+class TestBuildChangeTracking:
+    """Tests for _build_change_tracking."""
+
+    def test_new_status_when_no_previous(self):
+        ct = _build_change_tracking(None, "abc123", "hello")
+        assert ct.change_status == "new"
+        assert ct.content_hash == "abc123"
+        assert ct.previous_scrape_at is None
+        assert ct.diff is None
+
+    def test_same_status_when_hashes_match(self):
+        entry = CacheEntry(
+            url="http://example.com",
+            cached_at="2026-03-01T10:00:00Z",
+            expires_at="2026-03-02T10:00:00Z",
+            content_hash="abc123",
+            response={},
+        )
+        ct = _build_change_tracking(entry, "abc123", "hello")
+        assert ct.change_status == "same"
+        assert ct.previous_scrape_at == "2026-03-01T10:00:00Z"
+
+    def test_changed_status_when_hashes_differ(self):
+        entry = CacheEntry(
+            url="http://example.com",
+            cached_at="2026-03-01T10:00:00Z",
+            expires_at="2026-03-02T10:00:00Z",
+            content_hash="abc123",
+            response={},
+        )
+        ct = _build_change_tracking(entry, "def456", "world")
+        assert ct.change_status == "changed"
+        assert ct.diff is None  # No diff mode requested
+
+    def test_changed_status_when_no_previous_hash(self):
+        """When previous entry has no content_hash (old cache format), treat as changed."""
+        entry = CacheEntry(
+            url="http://example.com",
+            cached_at="2026-03-01T10:00:00Z",
+            expires_at="2026-03-02T10:00:00Z",
+            content_hash=None,
+            response={},
+        )
+        ct = _build_change_tracking(entry, "abc123", "hello")
+        assert ct.change_status == "changed"
+
+    def test_git_diff_mode_generates_diff(self):
+        entry = CacheEntry(
+            url="http://example.com",
+            cached_at="2026-03-01T10:00:00Z",
+            expires_at="2026-03-02T10:00:00Z",
+            content_hash="abc123",
+            response={"data": {"markdown": "Hello World\nLine 2\n"}},
+        )
+        ct = _build_change_tracking(
+            entry, "def456", "Hello World\nLine 2 changed\n", change_tracking_modes=["git-diff"]
+        )
+        assert ct.change_status == "changed"
+        assert ct.diff is not None
+        assert "--- previous" in ct.diff.text
+        assert "+++ current" in ct.diff.text
+        assert "-Line 2" in ct.diff.text
+        assert "+Line 2 changed" in ct.diff.text
+
+    def test_git_diff_not_generated_when_same(self):
+        entry = CacheEntry(
+            url="http://example.com",
+            cached_at="2026-03-01T10:00:00Z",
+            expires_at="2026-03-02T10:00:00Z",
+            content_hash="abc123",
+            response={"data": {"markdown": "same content"}},
+        )
+        ct = _build_change_tracking(entry, "abc123", "same content", change_tracking_modes=["git-diff"])
+        assert ct.change_status == "same"
+        assert ct.diff is None  # No diff when content is the same
+
+
+class TestGenerateUnifiedDiff:
+    """Tests for _generate_unified_diff."""
+
+    def test_generates_diff(self):
+        entry = CacheEntry(
+            url="http://example.com",
+            cached_at="2026-03-01T10:00:00Z",
+            expires_at="2026-03-02T10:00:00Z",
+            response={"data": {"markdown": "line 1\nline 2\n"}},
+        )
+        diff = _generate_unified_diff(entry, "line 1\nline 3\n")
+        assert diff is not None
+        assert "-line 2" in diff.text
+        assert "+line 3" in diff.text
+
+    def test_returns_none_when_identical(self):
+        entry = CacheEntry(
+            url="http://example.com",
+            cached_at="2026-03-01T10:00:00Z",
+            expires_at="2026-03-02T10:00:00Z",
+            response={"data": {"markdown": "same\n"}},
+        )
+        diff = _generate_unified_diff(entry, "same\n")
+        assert diff is None
+
+    def test_handles_missing_previous_markdown(self):
+        entry = CacheEntry(
+            url="http://example.com",
+            cached_at="2026-03-01T10:00:00Z",
+            expires_at="2026-03-02T10:00:00Z",
+            response={"data": {}},
+        )
+        diff = _generate_unified_diff(entry, "new content\n")
+        assert diff is not None
+        assert "+new content" in diff.text
+
+    def test_handles_none_current_markdown(self):
+        entry = CacheEntry(
+            url="http://example.com",
+            cached_at="2026-03-01T10:00:00Z",
+            expires_at="2026-03-02T10:00:00Z",
+            response={"data": {"markdown": "old content\n"}},
+        )
+        diff = _generate_unified_diff(entry, None)
+        assert diff is not None
+        assert "-old content" in diff.text
+
+
+class TestCacheManagerGetPrevious:
+    """Tests for CacheManager.get_previous."""
+
+    def test_returns_none_when_no_cache(self, tmp_path: Path):
+        cache = CacheManager(cache_dir=tmp_path / "cache")
+        result = cache.get_previous("http://example.com")
+        assert result is None
+
+    def test_returns_entry_ignoring_expiry(self, tmp_path: Path):
+        cache = CacheManager(cache_dir=tmp_path / "cache")
+        # Store an entry with very short max_age (already expired)
+        cache.set("http://example.com", {"success": True}, max_age=1, content_hash="abc123")
+
+        # get() would return None (expired), but get_previous should return it
+        entry = cache.get_previous("http://example.com")
+        assert entry is not None
+        assert entry.content_hash == "abc123"
+        assert entry.url == "http://example.com"
+
+    def test_stores_and_retrieves_content_hash(self, tmp_path: Path):
+        cache = CacheManager(cache_dir=tmp_path / "cache")
+        cache.set("http://example.com", {"success": True}, max_age=3600, content_hash="sha256test")
+
+        entry = cache.get_previous("http://example.com")
+        assert entry is not None
+        assert entry.content_hash == "sha256test"
+
+    def test_backwards_compatible_with_no_hash(self, tmp_path: Path):
+        """Old cache entries without content_hash should still work."""
+        cache = CacheManager(cache_dir=tmp_path / "cache")
+        cache.set("http://example.com", {"success": True}, max_age=3600)
+
+        entry = cache.get_previous("http://example.com")
+        assert entry is not None
+        assert entry.content_hash is None
+
+
+class TestChangeTrackingModels:
+    """Tests for change tracking Pydantic models."""
+
+    def test_change_tracking_data_serialisation(self):
+        ct = ChangeTrackingData(
+            previous_scrape_at="2026-03-01T10:00:00Z",
+            change_status="changed",
+            content_hash="abc123",
+        )
+        data = ct.model_dump()
+        assert data["change_status"] == "changed"
+        assert data["visibility"] == "visible"
+        assert data["diff"] is None
+
+    def test_change_tracking_with_diff(self):
+        ct = ChangeTrackingData(
+            change_status="changed",
+            diff=ChangeTrackingDiff(text="--- a\n+++ b\n@@ -1 +1 @@\n-old\n+new"),
+        )
+        data = ct.model_dump()
+        assert data["diff"]["text"].startswith("--- a")
+
+    def test_scrape_data_includes_change_tracking(self):
+        from supacrawl.models import ScrapeMetadata
+
+        sd = ScrapeData(
+            metadata=ScrapeMetadata(),
+            change_tracking=ChangeTrackingData(change_status="new", content_hash="abc"),
+        )
+        data = sd.model_dump()
+        assert data["change_tracking"]["change_status"] == "new"
+
+    def test_scrape_data_change_tracking_default_none(self):
+        from supacrawl.models import ScrapeMetadata
+
+        sd = ScrapeData(metadata=ScrapeMetadata())
+        assert sd.change_tracking is None
+
+    def test_all_change_statuses_valid(self):
+        for status in ("new", "same", "changed", "removed"):
+            ct = ChangeTrackingData(change_status=status)
+            assert ct.change_status == status

--- a/tests/test_change_tracking.py
+++ b/tests/test_change_tracking.py
@@ -2,6 +2,8 @@
 
 from pathlib import Path
 
+import pytest
+
 from supacrawl.cache import CacheEntry, CacheManager
 from supacrawl.models import ChangeTrackingData, ChangeTrackingDiff, ScrapeData
 from supacrawl.services.scrape import (
@@ -198,6 +200,170 @@ class TestCacheManagerGetPrevious:
         assert entry.content_hash is None
 
 
+class TestGenerateJsonComparison:
+    """Tests for ScrapeService._generate_json_comparison."""
+
+    @pytest.fixture
+    def service(self):
+        """Create a ScrapeService without cache (bare minimum for testing)."""
+        from supacrawl.services.scrape import ScrapeService
+
+        return ScrapeService()
+
+    @pytest.fixture
+    def previous_entry(self):
+        return CacheEntry(
+            url="http://example.com",
+            cached_at="2026-03-01T10:00:00Z",
+            expires_at="2026-03-02T10:00:00Z",
+            content_hash="abc123",
+            response={"data": {"markdown": "# Product\nPrice: $29/month\nPlan: Basic\n"}},
+        )
+
+    async def test_returns_changed_fields(self, service, previous_entry, monkeypatch):
+        """JSON comparison returns only fields that differ."""
+        call_count = 0
+
+        async def mock_extract_json(self, markdown, schema, prompt):
+            nonlocal call_count
+            call_count += 1
+            if "29" in markdown:
+                return {"price": "$29/month", "plan": "Basic"}
+            return {"price": "$39/month", "plan": "Basic"}
+
+        monkeypatch.setattr(
+            "supacrawl.services.scrape.ScrapeService._extract_json",
+            mock_extract_json,
+        )
+
+        result = await service._generate_json_comparison(
+            previous_entry=previous_entry,
+            current_markdown="# Product\nPrice: $39/month\nPlan: Basic\n",
+            current_json=None,
+            json_schema={"type": "object", "properties": {"price": {"type": "string"}}},
+            json_prompt=None,
+        )
+
+        assert result is not None
+        assert "price" in result
+        assert result["price"]["previous"] == "$29/month"
+        assert result["price"]["current"] == "$39/month"
+        assert "plan" not in result  # Same value, should be excluded
+        assert call_count == 2  # Both previous and current extracted
+
+    async def test_reuses_current_json(self, service, previous_entry, monkeypatch):
+        """When current_json is provided, skip redundant LLM call."""
+        call_count = 0
+
+        async def mock_extract_json(self, markdown, schema, prompt):
+            nonlocal call_count
+            call_count += 1
+            return {"price": "$29/month"}
+
+        monkeypatch.setattr(
+            "supacrawl.services.scrape.ScrapeService._extract_json",
+            mock_extract_json,
+        )
+
+        result = await service._generate_json_comparison(
+            previous_entry=previous_entry,
+            current_markdown="ignored",
+            current_json={"price": "$39/month"},  # Pre-extracted
+            json_schema=None,
+            json_prompt=None,
+        )
+
+        assert result is not None
+        assert result["price"]["previous"] == "$29/month"
+        assert result["price"]["current"] == "$39/month"
+        assert call_count == 1  # Only previous extracted
+
+    async def test_returns_none_when_both_extractions_fail(self, service, previous_entry, monkeypatch):
+        async def mock_extract_json(self, markdown, schema, prompt):
+            return None
+
+        monkeypatch.setattr(
+            "supacrawl.services.scrape.ScrapeService._extract_json",
+            mock_extract_json,
+        )
+
+        result = await service._generate_json_comparison(
+            previous_entry=previous_entry,
+            current_markdown="some content",
+            current_json=None,
+            json_schema=None,
+            json_prompt=None,
+        )
+        assert result is None
+
+    async def test_returns_none_when_no_previous_markdown(self, service):
+        entry = CacheEntry(
+            url="http://example.com",
+            cached_at="2026-03-01T10:00:00Z",
+            expires_at="2026-03-02T10:00:00Z",
+            response={"data": {}},  # No markdown
+        )
+
+        result = await service._generate_json_comparison(
+            previous_entry=entry,
+            current_markdown="some content",
+            current_json=None,
+            json_schema=None,
+            json_prompt=None,
+        )
+        assert result is None
+
+    async def test_returns_none_when_no_changes(self, service, previous_entry, monkeypatch):
+        """When all fields are identical, return None."""
+
+        async def mock_extract_json(self, markdown, schema, prompt):
+            return {"price": "$29/month", "plan": "Basic"}
+
+        monkeypatch.setattr(
+            "supacrawl.services.scrape.ScrapeService._extract_json",
+            mock_extract_json,
+        )
+
+        result = await service._generate_json_comparison(
+            previous_entry=previous_entry,
+            current_markdown="same content",
+            current_json=None,
+            json_schema=None,
+            json_prompt=None,
+        )
+        assert result is None
+
+    async def test_handles_new_fields(self, service, previous_entry, monkeypatch):
+        """Fields present in only one version are included."""
+        call_count = 0
+
+        async def mock_extract_json(self, markdown, schema, prompt):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return {"price": "$29/month"}  # Previous: no "tier" field
+            return {"price": "$29/month", "tier": "premium"}  # Current: added "tier"
+
+        monkeypatch.setattr(
+            "supacrawl.services.scrape.ScrapeService._extract_json",
+            mock_extract_json,
+        )
+
+        result = await service._generate_json_comparison(
+            previous_entry=previous_entry,
+            current_markdown="some content",
+            current_json=None,
+            json_schema=None,
+            json_prompt=None,
+        )
+
+        assert result is not None
+        assert "tier" in result
+        assert result["tier"]["previous"] is None
+        assert result["tier"]["current"] == "premium"
+        assert "price" not in result  # Same value
+
+
 class TestChangeTrackingModels:
     """Tests for change tracking Pydantic models."""
 
@@ -219,6 +385,15 @@ class TestChangeTrackingModels:
         )
         data = ct.model_dump()
         assert data["diff"]["text"].startswith("--- a")
+
+    def test_change_tracking_with_json_changes(self):
+        ct = ChangeTrackingData(
+            change_status="changed",
+            json_changes={"price": {"previous": "$29/month", "current": "$39/month"}},
+        )
+        data = ct.model_dump()
+        assert data["json_changes"]["price"]["previous"] == "$29/month"
+        assert data["json_changes"]["price"]["current"] == "$39/month"
 
     def test_scrape_data_includes_change_tracking(self):
         from supacrawl.models import ScrapeMetadata

--- a/tests/test_crawl_change_tracking.py
+++ b/tests/test_crawl_change_tracking.py
@@ -1,0 +1,285 @@
+"""Tests for crawl service change tracking integration."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from supacrawl.models import (
+    ChangeTrackingData,
+    CrawlEvent,
+    MapEvent,
+    MapLink,
+    MapResult,
+    ScrapeData,
+    ScrapeMetadata,
+    ScrapeResult,
+)
+from supacrawl.services.crawl import CrawlService
+
+
+def _make_scrape_result(url: str, change_status: str | None = None) -> ScrapeResult:
+    """Helper to build a ScrapeResult with optional change tracking."""
+    change_tracking = None
+    if change_status:
+        change_tracking = ChangeTrackingData(
+            change_status=change_status,
+            content_hash="abc123",
+        )
+    return ScrapeResult(
+        success=True,
+        data=ScrapeData(
+            markdown=f"# {url}",
+            metadata=ScrapeMetadata(source_url=url),
+            change_tracking=change_tracking,
+        ),
+    )
+
+
+def _make_map_events(urls: list[str]) -> list[MapEvent]:
+    """Helper to build map events ending with a complete event."""
+    links = [MapLink(url=u) for u in urls]
+    return [
+        MapEvent(type="discovery", discovered=len(urls), message="Found URLs"),
+        MapEvent(
+            type="complete",
+            discovered=len(urls),
+            result=MapResult(success=True, links=links),
+        ),
+    ]
+
+
+class TestCrawlChangeTracking:
+    """Tests for change tracking in CrawlService."""
+
+    @pytest.mark.asyncio
+    async def test_change_summary_in_complete_event(self):
+        """Change summary is emitted in the complete event when changeTracking format is used."""
+        urls = ["https://example.com/a", "https://example.com/b", "https://example.com/c"]
+        map_events = _make_map_events(urls)
+
+        mock_browser = MagicMock()
+        mock_map = AsyncMock()
+        mock_scrape = AsyncMock()
+
+        # Map service returns URLs
+        async def fake_map(**kwargs):
+            for e in map_events:
+                yield e
+
+        mock_map.map = fake_map
+
+        # Scrape service returns pages with different change statuses
+        statuses = ["new", "changed", "same"]
+        call_count = 0
+
+        async def fake_scrape(url, **kwargs):
+            nonlocal call_count
+            result = _make_scrape_result(url, statuses[call_count])
+            call_count += 1
+            return result
+
+        mock_scrape.scrape = fake_scrape
+
+        service = CrawlService(
+            browser=mock_browser,
+            map_service=mock_map,
+            scrape_service=mock_scrape,
+        )
+
+        events = []
+        async for event in service.crawl(
+            url="https://example.com",
+            limit=10,
+            formats=["markdown", "changeTracking"],
+        ):
+            events.append(event)
+
+        # Find the complete event
+        complete = next(e for e in events if e.type == "complete")
+        assert complete.change_summary is not None
+        assert complete.change_summary == {"new": 1, "changed": 1, "same": 1}
+
+    @pytest.mark.asyncio
+    async def test_no_change_summary_without_change_tracking_format(self):
+        """No change summary when changeTracking format is not requested."""
+        urls = ["https://example.com/a"]
+        map_events = _make_map_events(urls)
+
+        mock_browser = MagicMock()
+        mock_map = AsyncMock()
+        mock_scrape = AsyncMock()
+
+        async def fake_map(**kwargs):
+            for e in map_events:
+                yield e
+
+        mock_map.map = fake_map
+
+        async def fake_scrape(url, **kwargs):
+            return _make_scrape_result(url)
+
+        mock_scrape.scrape = fake_scrape
+
+        service = CrawlService(
+            browser=mock_browser,
+            map_service=mock_map,
+            scrape_service=mock_scrape,
+        )
+
+        events = []
+        async for event in service.crawl(
+            url="https://example.com",
+            limit=10,
+            formats=["markdown"],
+        ):
+            events.append(event)
+
+        complete = next(e for e in events if e.type == "complete")
+        assert complete.change_summary is None
+
+    @pytest.mark.asyncio
+    async def test_change_tracking_modes_passed_to_scrape(self):
+        """change_tracking_modes is threaded through to scrape calls."""
+        urls = ["https://example.com/a"]
+        map_events = _make_map_events(urls)
+
+        mock_browser = MagicMock()
+        mock_map = AsyncMock()
+        mock_scrape = AsyncMock()
+
+        async def fake_map(**kwargs):
+            for e in map_events:
+                yield e
+
+        mock_map.map = fake_map
+
+        captured_kwargs: list[dict] = []
+
+        async def fake_scrape(url, **kwargs):
+            captured_kwargs.append(kwargs)
+            return _make_scrape_result(url, "new")
+
+        mock_scrape.scrape = fake_scrape
+
+        service = CrawlService(
+            browser=mock_browser,
+            map_service=mock_map,
+            scrape_service=mock_scrape,
+        )
+
+        async for _ in service.crawl(
+            url="https://example.com",
+            limit=10,
+            formats=["markdown", "changeTracking"],
+            change_tracking_modes=["git-diff"],
+        ):
+            pass
+
+        assert len(captured_kwargs) == 1
+        assert captured_kwargs[0]["change_tracking_modes"] == ["git-diff"]
+
+    @pytest.mark.asyncio
+    async def test_change_tracking_adds_format_to_scrape(self):
+        """changeTracking in crawl formats includes changeTracking in per-page scrape formats."""
+        urls = ["https://example.com/a"]
+        map_events = _make_map_events(urls)
+
+        mock_browser = MagicMock()
+        mock_map = AsyncMock()
+        mock_scrape = AsyncMock()
+
+        async def fake_map(**kwargs):
+            for e in map_events:
+                yield e
+
+        mock_map.map = fake_map
+
+        captured_kwargs: list[dict] = []
+
+        async def fake_scrape(url, **kwargs):
+            captured_kwargs.append(kwargs)
+            return _make_scrape_result(url, "new")
+
+        mock_scrape.scrape = fake_scrape
+
+        service = CrawlService(
+            browser=mock_browser,
+            map_service=mock_map,
+            scrape_service=mock_scrape,
+        )
+
+        async for _ in service.crawl(
+            url="https://example.com",
+            limit=10,
+            formats=["markdown", "changeTracking"],
+        ):
+            pass
+
+        assert len(captured_kwargs) == 1
+        assert "changeTracking" in captured_kwargs[0]["formats"]
+
+    @pytest.mark.asyncio
+    async def test_change_summary_excludes_zero_counts(self):
+        """Change summary only includes statuses with non-zero counts."""
+        urls = ["https://example.com/a", "https://example.com/b"]
+        map_events = _make_map_events(urls)
+
+        mock_browser = MagicMock()
+        mock_map = AsyncMock()
+        mock_scrape = AsyncMock()
+
+        async def fake_map(**kwargs):
+            for e in map_events:
+                yield e
+
+        mock_map.map = fake_map
+
+        call_count = 0
+
+        async def fake_scrape(url, **kwargs):
+            nonlocal call_count
+            status = "changed" if call_count == 0 else "changed"
+            call_count += 1
+            return _make_scrape_result(url, status)
+
+        mock_scrape.scrape = fake_scrape
+
+        service = CrawlService(
+            browser=mock_browser,
+            map_service=mock_map,
+            scrape_service=mock_scrape,
+        )
+
+        events = []
+        async for event in service.crawl(
+            url="https://example.com",
+            limit=10,
+            formats=["markdown", "changeTracking"],
+        ):
+            events.append(event)
+
+        complete = next(e for e in events if e.type == "complete")
+        assert complete.change_summary == {"changed": 2}
+        # "new", "same", "removed" should not be present
+        assert "new" not in complete.change_summary
+        assert "same" not in complete.change_summary
+        assert "removed" not in complete.change_summary
+
+
+class TestCrawlEventModel:
+    """Tests for CrawlEvent change_summary field."""
+
+    def test_crawl_event_change_summary_default_none(self):
+        """CrawlEvent.change_summary defaults to None."""
+        event = CrawlEvent(type="complete", completed=5, total=5)
+        assert event.change_summary is None
+
+    def test_crawl_event_change_summary_populated(self):
+        """CrawlEvent.change_summary can be set."""
+        event = CrawlEvent(
+            type="complete",
+            completed=5,
+            total=5,
+            change_summary={"new": 2, "changed": 3},
+        )
+        assert event.change_summary == {"new": 2, "changed": 3}

--- a/tests/test_device_emulation.py
+++ b/tests/test_device_emulation.py
@@ -1,0 +1,290 @@
+"""Tests for mobile device emulation (issue #83).
+
+Tests cover:
+- BrowserManager device config resolution and context options
+- ScrapeService device parameter threading and cache variants
+- CLI --mobile, --device, and --list-devices options
+- MCP tool mobile/device parameters
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from supacrawl.services.browser import BrowserManager
+from supacrawl.services.scrape import ScrapeService
+
+# ---------------------------------------------------------------------------
+# BrowserManager — device config resolution
+# ---------------------------------------------------------------------------
+
+
+class TestBrowserManagerDeviceConfig:
+    """Test BrowserManager device emulation support."""
+
+    def test_resolve_device_config_raises_without_playwright(self):
+        """_resolve_device_config raises if Playwright not started."""
+        bm = BrowserManager()
+        with pytest.raises(RuntimeError, match="Playwright not started"):
+            bm._resolve_device_config("iPhone 14")
+
+    def test_resolve_device_config_unknown_device(self):
+        """_resolve_device_config raises ValueError for unknown device."""
+        bm = BrowserManager()
+        bm._playwright = MagicMock()
+        bm._playwright.devices = {"iPhone 14": {"user_agent": "ua"}}
+
+        with pytest.raises(ValueError, match="Unknown device 'Banana Phone'"):
+            bm._resolve_device_config("Banana Phone")
+
+    def test_resolve_device_config_suggests_close_matches(self):
+        """Error message includes close matches for unknown device names."""
+        bm = BrowserManager()
+        bm._playwright = MagicMock()
+        bm._playwright.devices = {
+            "iPhone 14": {},
+            "iPhone 14 Pro": {},
+            "iPhone 14 Pro Max": {},
+            "Pixel 7": {},
+        }
+
+        with pytest.raises(ValueError, match="Did you mean.*iPhone 14"):
+            bm._resolve_device_config("iPhone 14 Plus")
+
+    def test_resolve_device_config_strips_default_browser_type(self):
+        """Device config should not include default_browser_type."""
+        bm = BrowserManager()
+        bm._playwright = MagicMock()
+        bm._playwright.devices = {
+            "iPhone 14": {
+                "user_agent": "Mozilla/5.0 (iPhone)",
+                "viewport": {"width": 390, "height": 844},
+                "device_scale_factor": 3,
+                "is_mobile": True,
+                "has_touch": True,
+                "default_browser_type": "webkit",
+            }
+        }
+
+        config = bm._resolve_device_config("iPhone 14")
+        assert "default_browser_type" not in config
+        assert config["user_agent"] == "Mozilla/5.0 (iPhone)"
+        assert config["viewport"] == {"width": 390, "height": 844}
+        assert config["is_mobile"] is True
+
+    def test_build_context_options_without_device(self):
+        """Without device, _build_context_options works as before."""
+        bm = BrowserManager()
+        bm._playwright = MagicMock()
+        options = bm._build_context_options()
+        # No device-specific keys
+        assert "is_mobile" not in options
+        assert "has_touch" not in options
+
+    def test_build_context_options_with_device(self):
+        """With device, _build_context_options merges device settings."""
+        bm = BrowserManager()
+        bm._playwright = MagicMock()
+        bm._playwright.devices = {
+            "Pixel 7": {
+                "user_agent": "Mozilla/5.0 (Linux; Android)",
+                "viewport": {"width": 412, "height": 915},
+                "device_scale_factor": 2.625,
+                "is_mobile": True,
+                "has_touch": True,
+                "default_browser_type": "chromium",
+            }
+        }
+
+        options = bm._build_context_options(device="Pixel 7")
+        assert options["user_agent"] == "Mozilla/5.0 (Linux; Android)"
+        assert options["viewport"] == {"width": 412, "height": 915}
+        assert options["is_mobile"] is True
+        assert options["has_touch"] is True
+        assert "default_browser_type" not in options
+
+    def test_explicit_user_agent_overrides_device(self):
+        """An explicit user_agent on BrowserManager overrides the device's UA."""
+        bm = BrowserManager(user_agent="Custom/UA")
+        bm._playwright = MagicMock()
+        bm._playwright.devices = {
+            "iPhone 14": {
+                "user_agent": "Mozilla/5.0 (iPhone)",
+                "viewport": {"width": 390, "height": 844},
+                "device_scale_factor": 3,
+                "is_mobile": True,
+                "has_touch": True,
+                "default_browser_type": "webkit",
+            }
+        }
+
+        options = bm._build_context_options(device="iPhone 14")
+        # Explicit UA overrides device UA
+        assert options["user_agent"] == "Custom/UA"
+        # Device viewport still applied
+        assert options["viewport"] == {"width": 390, "height": 844}
+
+
+# ---------------------------------------------------------------------------
+# BrowserManager — fetch_page device validation
+# ---------------------------------------------------------------------------
+
+
+class TestFetchPageDeviceValidation:
+    """Test fetch_page device parameter validation."""
+
+    @pytest.mark.asyncio
+    async def test_device_with_camoufox_raises(self):
+        """Device emulation with Camoufox should raise ValueError."""
+        bm = BrowserManager.__new__(BrowserManager)
+        bm.engine = "camoufox"
+        bm._browser = MagicMock()
+
+        with pytest.raises(ValueError, match="not supported with the Camoufox engine"):
+            await bm.fetch_page("https://example.com", device="iPhone 14")
+
+
+# ---------------------------------------------------------------------------
+# BrowserManager — list_devices
+# ---------------------------------------------------------------------------
+
+
+class TestListDevices:
+    """Test list_devices helper."""
+
+    @pytest.mark.asyncio
+    async def test_list_devices_raises_without_playwright(self):
+        """list_devices raises if Playwright not started."""
+        bm = BrowserManager()
+        with pytest.raises(RuntimeError, match="Playwright not started"):
+            await bm.list_devices()
+
+    @pytest.mark.asyncio
+    async def test_list_devices_returns_sorted(self):
+        """list_devices returns sorted device names."""
+        bm = BrowserManager()
+        bm._playwright = MagicMock()
+        bm._playwright.devices = {"Pixel 7": {}, "iPhone 14": {}, "iPad Pro": {}}
+
+        result = await bm.list_devices()
+        # ASCII sort: uppercase 'P' (80) < lowercase 'i' (105)
+        assert result == ["Pixel 7", "iPad Pro", "iPhone 14"]
+
+
+# ---------------------------------------------------------------------------
+# ScrapeService — device threading
+# ---------------------------------------------------------------------------
+
+
+class TestScrapeServiceDevice:
+    """Test ScrapeService device parameter threading."""
+
+    @pytest.mark.asyncio
+    async def test_device_passed_to_browser_fetch_page(self):
+        """Device parameter should be forwarded to browser.fetch_page()."""
+        service = ScrapeService(headless=True)
+        assert service._owns_browser is True
+
+        with (
+            patch.object(BrowserManager, "__aenter__", new_callable=AsyncMock) as mock_enter,
+            patch.object(BrowserManager, "__aexit__", new_callable=AsyncMock),
+            patch.object(BrowserManager, "__init__", return_value=None),
+            patch.object(BrowserManager, "fetch_page", new_callable=AsyncMock) as mock_fetch,
+        ):
+            mock_enter.return_value = MagicMock()
+
+            try:
+                await service.scrape("https://example.com", device="iPhone 14")
+            except Exception:
+                pass  # We only care about the fetch_page call
+
+            # Verify fetch_page was actually called and device was passed
+            assert mock_fetch.called, "fetch_page was never called"
+            _, kwargs = mock_fetch.call_args
+            assert kwargs.get("device") == "iPhone 14"
+
+
+# ---------------------------------------------------------------------------
+# ScrapeService — cache variant
+# ---------------------------------------------------------------------------
+
+
+class TestScrapeServiceCacheVariant:
+    """Test cache variant includes device for differentiation."""
+
+    @pytest.mark.asyncio
+    async def test_device_creates_cache_variant(self):
+        """A device parameter should produce a distinct cache variant."""
+        # This is tested via the cache key generation in ScrapeService.scrape()
+        # The implementation builds variant_parts including device name
+        # We verify this indirectly via the cache interaction
+        from supacrawl.cache import CacheManager
+
+        cm = CacheManager.__new__(CacheManager)
+        cm.cache_dir = None
+        cm.pages_dir = None
+        cm.index_path = None
+
+        # Same URL, different variants should produce different keys
+        key_desktop = cm._cache_key("https://example.com")
+        key_mobile = cm._cache_key("https://example.com", variant="device=iPhone 14")
+        key_other = cm._cache_key("https://example.com", variant="device=Pixel 7")
+
+        assert key_desktop != key_mobile
+        assert key_mobile != key_other
+        assert key_desktop != key_other
+
+    @pytest.mark.asyncio
+    async def test_device_plus_screenshot_variant(self):
+        """Device + screenshot_full_page=False should combine in variant."""
+        from supacrawl.cache import CacheManager
+
+        cm = CacheManager.__new__(CacheManager)
+        cm.cache_dir = None
+        cm.pages_dir = None
+        cm.index_path = None
+
+        key_combined = cm._cache_key(
+            "https://example.com",
+            variant="device=iPhone 14|screenshot_full_page=False",
+        )
+        key_device_only = cm._cache_key(
+            "https://example.com",
+            variant="device=iPhone 14",
+        )
+
+        assert key_combined != key_device_only
+
+
+# ---------------------------------------------------------------------------
+# CLI — --mobile and --device options
+# ---------------------------------------------------------------------------
+
+
+class TestCLIDeviceOptions:
+    """Test CLI --mobile and --device options."""
+
+    def test_mobile_resolves_to_default_device(self):
+        """--mobile flag should resolve to DEFAULT_MOBILE_DEVICE."""
+        from supacrawl.models import DEFAULT_MOBILE_DEVICE
+
+        assert DEFAULT_MOBILE_DEVICE == "iPhone 14"
+
+    def test_device_overrides_mobile(self):
+        """When both --mobile and --device are given, --device wins."""
+        # This is tested by the resolution logic:
+        # resolved_device = device if device else (DEFAULT_MOBILE_DEVICE if mobile else None)
+        from supacrawl.models import DEFAULT_MOBILE_DEVICE
+
+        mobile = True
+        device = "Pixel 7"
+
+        resolved = device if device else (DEFAULT_MOBILE_DEVICE if mobile else None)
+        assert resolved == "Pixel 7"
+
+    def test_neither_mobile_nor_device_gives_none(self):
+        """Without --mobile or --device, resolved device is None."""
+        mobile = False
+        device = None
+        resolved = device if device else ("iPhone 14" if mobile else None)
+        assert resolved is None

--- a/tests/test_iframe_expansion.py
+++ b/tests/test_iframe_expansion.py
@@ -1,0 +1,107 @@
+"""Tests for iframe expansion in BrowserManager."""
+
+import pytest
+
+from supacrawl.services.browser import (
+    IFRAME_BLOCKED_DOMAINS,
+    MAX_IFRAMES_PER_PAGE,
+    _is_blocked_iframe_domain,
+)
+
+
+class TestIsBlockedIframeDomain:
+    """Tests for _is_blocked_iframe_domain helper."""
+
+    def test_exact_match(self):
+        """Exact domain match is blocked."""
+        assert _is_blocked_iframe_domain("doubleclick.net") is True
+
+    def test_subdomain_match(self):
+        """Subdomain of blocked domain is blocked."""
+        assert _is_blocked_iframe_domain("ad.doubleclick.net") is True
+        assert _is_blocked_iframe_domain("stats.google-analytics.com") is True
+
+    def test_unblocked_domain(self):
+        """Normal domains are not blocked."""
+        assert _is_blocked_iframe_domain("example.com") is False
+        assert _is_blocked_iframe_domain("docs.python.org") is False
+
+    def test_case_insensitive(self):
+        """Domain matching is case-insensitive."""
+        assert _is_blocked_iframe_domain("DoubleClick.Net") is True
+        assert _is_blocked_iframe_domain("GOOGLETAGMANAGER.COM") is True
+
+    def test_partial_match_not_blocked(self):
+        """Partial domain match (not subdomain) is not blocked."""
+        # "notdoubleclick.net" is not a subdomain of "doubleclick.net"
+        assert _is_blocked_iframe_domain("notdoubleclick.net") is False
+
+    def test_empty_hostname(self):
+        """Empty hostname is not blocked."""
+        assert _is_blocked_iframe_domain("") is False
+
+    def test_ad_domains_blocked(self):
+        """Known ad network domains are blocked."""
+        ad_domains = ["googlesyndication.com", "amazon-adsystem.com", "taboola.com", "outbrain.com"]
+        for domain in ad_domains:
+            assert _is_blocked_iframe_domain(domain) is True, f"{domain} should be blocked"
+
+    def test_analytics_domains_blocked(self):
+        """Known analytics domains are blocked."""
+        analytics_domains = ["google-analytics.com", "googletagmanager.com", "hotjar.com"]
+        for domain in analytics_domains:
+            assert _is_blocked_iframe_domain(domain) is True, f"{domain} should be blocked"
+
+    def test_captcha_domains_blocked(self):
+        """Known CAPTCHA domains are blocked."""
+        captcha_domains = ["recaptcha.net", "hcaptcha.com", "challenges.cloudflare.com"]
+        for domain in captcha_domains:
+            assert _is_blocked_iframe_domain(domain) is True, f"{domain} should be blocked"
+
+
+class TestIframeConstants:
+    """Tests for iframe-related constants."""
+
+    def test_blocked_domains_is_frozenset(self):
+        """Blocked domains constant is immutable."""
+        assert isinstance(IFRAME_BLOCKED_DOMAINS, frozenset)
+
+    def test_blocked_domains_not_empty(self):
+        """Blocked domains list has entries."""
+        assert len(IFRAME_BLOCKED_DOMAINS) > 0
+
+    def test_max_iframes_per_page_reasonable(self):
+        """Max iframes limit is a reasonable number."""
+        assert MAX_IFRAMES_PER_PAGE > 0
+        assert MAX_IFRAMES_PER_PAGE <= 50
+
+
+class TestExpandIframesIntegration:
+    """Integration tests for iframe expansion (require Playwright)."""
+
+    @pytest.mark.e2e
+    @pytest.mark.asyncio
+    async def test_expand_iframes_same_origin(self):
+        """Same-origin iframe content is expanded inline."""
+        from supacrawl.services.browser import BrowserManager
+
+        async with BrowserManager() as browser:
+            # Just verify the method exists and is callable
+            page_content = await browser.fetch_page(
+                "https://example.com",
+                expand_iframes="same-origin",
+            )
+            assert page_content.html is not None
+
+    @pytest.mark.e2e
+    @pytest.mark.asyncio
+    async def test_expand_iframes_none_mode(self):
+        """With mode 'none', iframes are not expanded."""
+        from supacrawl.services.browser import BrowserManager
+
+        async with BrowserManager() as browser:
+            page_content = await browser.fetch_page(
+                "https://example.com",
+                expand_iframes="none",
+            )
+            assert page_content.html is not None

--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -531,10 +531,7 @@ class TestScrapeServicePdfRouting:
         from supacrawl.services.scrape import ScrapeService
 
         # If parse_pdf is None, the PDF detection is skipped entirely
-        with (
-            patch("supacrawl.services.pdf.is_pdf_url") as mock_detect,
-            patch("supacrawl.services.pdf.detect_pdf_content_type") as mock_head,
-        ):
+        with patch("supacrawl.services.pdf.is_pdf_url") as mock_detect:
             service = ScrapeService(headless=True)
             # This will fail because we haven't set up a browser, but
             # the important thing is that PDF detection was NOT called
@@ -548,6 +545,28 @@ class TestScrapeServicePdfRouting:
                 pass  # Expected to fail (no browser)
 
             mock_detect.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_auto_mode_no_head_request_for_extensionless_urls(self):
+        """Auto mode should not send HEAD requests for extensionless URLs."""
+        from supacrawl.services.scrape import ScrapeService
+
+        # Extensionless URL should only check is_pdf_url (False), no HEAD request
+        with (
+            patch("supacrawl.services.pdf.is_pdf_url", return_value=False) as mock_url_check,
+            patch("supacrawl.services.pdf.detect_pdf_content_type") as mock_head,
+        ):
+            service = ScrapeService(headless=True)
+            try:
+                await service.scrape(
+                    url="https://example.gov.au/pacman/document/123",
+                    formats=["markdown"],
+                    parse_pdf="auto",
+                )
+            except Exception:
+                pass  # Expected to fail (no browser)
+
+            mock_url_check.assert_called_once()
             mock_head.assert_not_called()
 
     @pytest.mark.asyncio

--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -1,0 +1,663 @@
+"""Tests for PDF URL parsing (issue #82).
+
+Tests cover:
+- PDF URL detection (extension and Content-Type)
+- PDF byte validation (%PDF magic)
+- Text extraction via pdfplumber
+- Table-to-markdown conversion
+- Heading detection heuristics
+- PDF metadata extraction
+- OCR availability checks
+- Auto mode fallback logic
+- ScrapeService PDF routing
+- CLI --parse-pdf option
+- MCP parse_pdf parameter
+"""
+
+import io
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from supacrawl.services.pdf import (
+    MAX_PDF_SIZE,
+    MIN_WORDS_FOR_SUCCESS,
+    PdfExtractionResult,
+    PdfMetadata,
+    _clean_cell,
+    _normalise_pdf_date,
+    _table_to_markdown,
+    is_pdf_bytes,
+    is_pdf_url,
+    needs_content_type_check,
+)
+
+# ---------------------------------------------------------------------------
+# PDF URL detection
+# ---------------------------------------------------------------------------
+
+
+class TestIsPdfUrl:
+    """Test is_pdf_url detection by file extension."""
+
+    def test_simple_pdf_url(self):
+        assert is_pdf_url("https://example.com/report.pdf") is True
+
+    def test_pdf_url_with_path(self):
+        assert is_pdf_url("https://example.com/docs/2024/report.pdf") is True
+
+    def test_pdf_url_with_query_params(self):
+        assert is_pdf_url("https://example.com/report.pdf?v=2") is True
+
+    def test_pdf_url_with_fragment(self):
+        assert is_pdf_url("https://example.com/report.pdf#page=5") is True
+
+    def test_pdf_url_case_insensitive(self):
+        assert is_pdf_url("https://example.com/report.PDF") is True
+
+    def test_non_pdf_url(self):
+        assert is_pdf_url("https://example.com/page.html") is False
+
+    def test_pdf_in_path_but_not_extension(self):
+        """URL containing 'pdf' in path but not as extension."""
+        assert is_pdf_url("https://example.com/pdf-viewer/page") is False
+
+    def test_no_extension(self):
+        assert is_pdf_url("https://example.com/report") is False
+
+
+# ---------------------------------------------------------------------------
+# PDF magic byte detection
+# ---------------------------------------------------------------------------
+
+
+class TestIsPdfBytes:
+    """Test PDF magic byte detection."""
+
+    def test_valid_pdf_bytes(self):
+        data = b"%PDF-1.7\nsome content"
+        assert is_pdf_bytes(data) is True
+
+    def test_pdf_bytes_with_leading_whitespace(self):
+        """Some PDFs have a BOM or whitespace before %PDF."""
+        data = b"\xef\xbb\xbf%PDF-1.4\nmore content"
+        assert is_pdf_bytes(data) is True
+
+    def test_non_pdf_bytes(self):
+        data = b"<html><body>Not a PDF</body></html>"
+        assert is_pdf_bytes(data) is False
+
+    def test_empty_bytes(self):
+        assert is_pdf_bytes(b"") is False
+
+    def test_short_bytes(self):
+        assert is_pdf_bytes(b"AB") is False
+
+
+# ---------------------------------------------------------------------------
+# Content-Type detection
+# ---------------------------------------------------------------------------
+
+
+class TestDetectPdfContentType:
+    """Test HEAD request Content-Type detection."""
+
+    @pytest.mark.asyncio
+    async def test_detects_pdf_content_type(self):
+        from supacrawl.services.pdf import detect_pdf_content_type
+
+        mock_response = MagicMock()
+        mock_response.headers = {"content-type": "application/pdf"}
+
+        with patch("supacrawl.services.pdf.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.head = AsyncMock(return_value=mock_response)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=None)
+            mock_client_cls.return_value = mock_client
+
+            result = await detect_pdf_content_type("https://example.com/report")
+            assert result is True
+
+    @pytest.mark.asyncio
+    async def test_non_pdf_content_type(self):
+        from supacrawl.services.pdf import detect_pdf_content_type
+
+        mock_response = MagicMock()
+        mock_response.headers = {"content-type": "text/html; charset=utf-8"}
+
+        with patch("supacrawl.services.pdf.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.head = AsyncMock(return_value=mock_response)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=None)
+            mock_client_cls.return_value = mock_client
+
+            result = await detect_pdf_content_type("https://example.com/page")
+            assert result is False
+
+    @pytest.mark.asyncio
+    async def test_network_error_returns_false(self):
+        from supacrawl.services.pdf import detect_pdf_content_type
+
+        with patch("supacrawl.services.pdf.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.head = AsyncMock(side_effect=Exception("Connection refused"))
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=None)
+            mock_client_cls.return_value = mock_client
+
+            result = await detect_pdf_content_type("https://unreachable.com/file")
+            assert result is False
+
+
+# ---------------------------------------------------------------------------
+# HEAD request optimisation
+# ---------------------------------------------------------------------------
+
+
+class TestNeedsContentTypeCheck:
+    """Test smart HEAD request skipping for known non-PDF extensions."""
+
+    def test_html_url_skips_check(self):
+        assert needs_content_type_check("https://example.com/page.html") is False
+
+    def test_php_url_skips_check(self):
+        assert needs_content_type_check("https://example.com/index.php") is False
+
+    def test_json_url_skips_check(self):
+        assert needs_content_type_check("https://example.com/api/data.json") is False
+
+    def test_image_url_skips_check(self):
+        assert needs_content_type_check("https://example.com/photo.jpg") is False
+
+    def test_pdf_url_skips_check(self):
+        """PDF URL is already detected — no HEAD needed."""
+        assert needs_content_type_check("https://example.com/report.pdf") is False
+
+    def test_no_extension_needs_check(self):
+        """URL with no extension is ambiguous — needs HEAD request."""
+        assert needs_content_type_check("https://example.com/document") is True
+
+    def test_path_only_needs_check(self):
+        assert needs_content_type_check("https://example.com/api/v1/document/123") is True
+
+    def test_root_url_needs_check(self):
+        assert needs_content_type_check("https://example.com/") is True
+
+    def test_unknown_extension_needs_check(self):
+        assert needs_content_type_check("https://example.com/file.xyz") is True
+
+
+# ---------------------------------------------------------------------------
+# PDF size limit
+# ---------------------------------------------------------------------------
+
+
+class TestPdfSizeLimit:
+    """Test PDF download size limit."""
+
+    @pytest.mark.asyncio
+    async def test_oversized_pdf_raises_value_error(self):
+        from supacrawl.services.pdf import download_pdf
+
+        # Create a mock response that exceeds the size limit
+        large_content = b"%PDF-" + b"x" * (MAX_PDF_SIZE + 1)
+        mock_response = MagicMock()
+        mock_response.content = large_content
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("supacrawl.services.pdf.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(return_value=mock_response)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=None)
+            mock_client_cls.return_value = mock_client
+
+            with pytest.raises(ValueError, match="too large"):
+                await download_pdf("https://example.com/huge.pdf")
+
+
+# ---------------------------------------------------------------------------
+# PDF date normalisation
+# ---------------------------------------------------------------------------
+
+
+class TestNormalisePdfDate:
+    """Test PDF date string normalisation."""
+
+    def test_standard_pdf_date(self):
+        result = _normalise_pdf_date("D:20240115120000Z")
+        assert result == "2024-01-15T12:00:00Z"
+
+    def test_date_without_prefix(self):
+        result = _normalise_pdf_date("20240115120000")
+        assert result == "2024-01-15T12:00:00Z"
+
+    def test_date_only(self):
+        result = _normalise_pdf_date("D:20240115")
+        assert result == "2024-01-15T00:00:00Z"
+
+    def test_unparseable_date(self):
+        result = _normalise_pdf_date("not-a-date")
+        assert result == "not-a-date"
+
+
+# ---------------------------------------------------------------------------
+# Table to markdown
+# ---------------------------------------------------------------------------
+
+
+class TestTableToMarkdown:
+    """Test pdfplumber table conversion to markdown."""
+
+    def test_simple_table(self):
+        table = [
+            ["Name", "Age", "City"],
+            ["Alice", "30", "Sydney"],
+            ["Bob", "25", "Melbourne"],
+        ]
+        result = _table_to_markdown(table)
+        lines = result.split("\n")
+        assert len(lines) == 4
+        assert "| Name | Age | City |" in lines[0]
+        assert "| --- | --- | --- |" in lines[1]
+        assert "| Alice | 30 | Sydney |" in lines[2]
+
+    def test_table_with_none_cells(self):
+        table = [
+            ["Header", None],
+            [None, "Value"],
+        ]
+        result = _table_to_markdown(table)
+        assert "| Header |  |" in result
+        assert "|  | Value |" in result
+
+    def test_table_with_pipe_in_cell(self):
+        table = [
+            ["Name", "Description"],
+            ["Test", "Has | pipe"],
+        ]
+        result = _table_to_markdown(table)
+        assert "Has \\| pipe" in result
+
+    def test_empty_table(self):
+        assert _table_to_markdown([]) == ""
+        assert _table_to_markdown([[]]) == ""
+
+
+# ---------------------------------------------------------------------------
+# Clean cell helper
+# ---------------------------------------------------------------------------
+
+
+class TestCleanCell:
+    """Test cell cleaning for markdown tables."""
+
+    def test_none_cell(self):
+        assert _clean_cell(None) == ""
+
+    def test_newline_in_cell(self):
+        assert _clean_cell("line1\nline2") == "line1 line2"
+
+    def test_pipe_escaped(self):
+        assert _clean_cell("a|b") == "a\\|b"
+
+    def test_whitespace_stripped(self):
+        assert _clean_cell("  hello  ") == "hello"
+
+
+# ---------------------------------------------------------------------------
+# Text extraction (with real pdfplumber)
+# ---------------------------------------------------------------------------
+
+
+def _make_simple_pdf(text: str = "Hello World. This is a test PDF document.") -> bytes:
+    """Create a minimal PDF with text for testing.
+
+    Uses pdfplumber-compatible PDF generation via pypdfium2.
+    """
+    # Use fpdf2 if available, otherwise create a minimal valid PDF manually
+    try:
+        from fpdf import FPDF
+
+        pdf = FPDF()
+        pdf.add_page()
+        pdf.set_font("Helvetica", size=12)
+        pdf.multi_cell(0, 10, text)
+        return pdf.output()
+    except ImportError:
+        pass
+
+    # Fallback: create a minimal PDF with raw PDF commands
+    # This creates a valid PDF that pdfplumber can read
+    content_stream = f"BT /F1 12 Tf 72 720 Td ({text}) Tj ET"
+    content_bytes = content_stream.encode("latin-1")
+
+    objects = []
+    # Object 1: Catalog
+    objects.append(b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n")
+    # Object 2: Pages
+    objects.append(b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n")
+    # Object 3: Page
+    objects.append(
+        b"3 0 obj\n<< /Type /Page /Parent 2 0 R "
+        b"/MediaBox [0 0 612 792] "
+        b"/Contents 4 0 R "
+        b"/Resources << /Font << /F1 5 0 R >> >> >>\nendobj\n"
+    )
+    # Object 4: Content stream
+    objects.append(
+        f"4 0 obj\n<< /Length {len(content_bytes)} >>\nstream\n".encode("latin-1")
+        + content_bytes
+        + b"\nendstream\nendobj\n"
+    )
+    # Object 5: Font
+    objects.append(b"5 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>\nendobj\n")
+
+    # Build PDF
+    pdf = io.BytesIO()
+    pdf.write(b"%PDF-1.4\n")
+
+    offsets = []
+    for obj in objects:
+        offsets.append(pdf.tell())
+        pdf.write(obj)
+
+    # Cross-reference table
+    xref_start = pdf.tell()
+    pdf.write(b"xref\n")
+    pdf.write(f"0 {len(objects) + 1}\n".encode())
+    pdf.write(b"0000000000 65535 f \n")
+    for offset in offsets:
+        pdf.write(f"{offset:010d} 00000 n \n".encode())
+
+    # Trailer
+    pdf.write(b"trailer\n")
+    pdf.write(f"<< /Size {len(objects) + 1} /Root 1 0 R >>\n".encode())
+    pdf.write(b"startxref\n")
+    pdf.write(f"{xref_start}\n".encode())
+    pdf.write(b"%%EOF\n")
+
+    return pdf.getvalue()
+
+
+class TestExtractText:
+    """Test text extraction from PDFs."""
+
+    def test_extract_from_minimal_pdf(self):
+        from supacrawl.services.pdf import extract_text
+
+        pdf_bytes = _make_simple_pdf()
+        result = extract_text(pdf_bytes)
+
+        assert isinstance(result, PdfExtractionResult)
+        assert result.metadata.page_count >= 1
+        # The text should be extracted (exact content depends on PDF generation method)
+        assert len(result.markdown) > 0
+
+    def test_extract_returns_metadata(self):
+        from supacrawl.services.pdf import extract_text
+
+        pdf_bytes = _make_simple_pdf()
+        result = extract_text(pdf_bytes)
+
+        assert isinstance(result.metadata, PdfMetadata)
+        assert result.metadata.page_count >= 1
+
+    def test_extract_from_invalid_bytes_raises(self):
+        from pdfplumber.utils.exceptions import PdfminerException
+
+        from supacrawl.services.pdf import extract_text
+
+        with pytest.raises(PdfminerException):
+            extract_text(b"not a pdf")
+
+
+# ---------------------------------------------------------------------------
+# OCR availability
+# ---------------------------------------------------------------------------
+
+
+class TestOcrAvailability:
+    """Test OCR dependency detection."""
+
+    def test_ocr_not_available_without_packages(self):
+        from supacrawl.services.pdf import _is_ocr_available
+
+        with patch.dict("sys.modules", {"pytesseract": None, "pdf2image": None}):
+            # Force re-evaluation by importing fresh
+            # The function checks import availability
+            pass
+        # Just verify it returns a bool
+        result = _is_ocr_available()
+        assert isinstance(result, bool)
+
+    def test_pdfplumber_is_available(self):
+        from supacrawl.services.pdf import _is_pdfplumber_available
+
+        assert _is_pdfplumber_available() is True
+
+
+# ---------------------------------------------------------------------------
+# parse_pdf orchestrator
+# ---------------------------------------------------------------------------
+
+
+class TestParsePdf:
+    """Test the parse_pdf orchestrator function."""
+
+    @pytest.mark.asyncio
+    async def test_fast_mode_text_extraction(self):
+        from supacrawl.services.pdf import parse_pdf
+
+        pdf_bytes = _make_simple_pdf("This is a test document with enough words to pass the threshold.")
+        result = await parse_pdf(url="https://example.com/test.pdf", mode="fast", pdf_bytes=pdf_bytes)
+
+        assert isinstance(result, PdfExtractionResult)
+        assert len(result.markdown) > 0
+
+    @pytest.mark.asyncio
+    async def test_auto_mode_succeeds_with_text(self):
+        """Auto mode should succeed with text extraction when text is present."""
+        from supacrawl.services.pdf import parse_pdf
+
+        # Create PDF with enough words to pass the MIN_WORDS_FOR_SUCCESS threshold
+        words = " ".join(f"word{i}" for i in range(MIN_WORDS_FOR_SUCCESS + 10))
+        pdf_bytes = _make_simple_pdf(words)
+        result = await parse_pdf(url="https://example.com/test.pdf", mode="auto", pdf_bytes=pdf_bytes)
+
+        assert len(result.markdown) > 0
+
+    @pytest.mark.asyncio
+    async def test_invalid_pdf_raises_value_error(self):
+        from supacrawl.services.pdf import parse_pdf
+
+        with pytest.raises(ValueError, match="not a valid PDF"):
+            await parse_pdf(
+                url="https://example.com/fake.pdf",
+                mode="fast",
+                pdf_bytes=b"<html>Not a PDF</html>",
+            )
+
+    @pytest.mark.asyncio
+    async def test_ocr_mode_without_packages_raises(self):
+        from supacrawl.services.pdf import parse_pdf
+
+        pdf_bytes = _make_simple_pdf()
+
+        with patch("supacrawl.services.pdf._is_ocr_available", return_value=False):
+            with pytest.raises(ImportError, match="supacrawl\\[pdf-ocr\\]"):
+                await parse_pdf(url="https://example.com/test.pdf", mode="ocr", pdf_bytes=pdf_bytes)
+
+
+# ---------------------------------------------------------------------------
+# ScrapeService PDF routing
+# ---------------------------------------------------------------------------
+
+
+class TestScrapeServicePdfRouting:
+    """Test that ScrapeService routes PDF URLs to the PDF pipeline."""
+
+    @pytest.mark.asyncio
+    async def test_pdf_url_bypasses_browser(self):
+        """PDF URLs should be processed without launching a browser."""
+        from supacrawl.services.scrape import ScrapeService
+
+        pdf_bytes = _make_simple_pdf("Enough words for a reasonable extraction result here in this document.")
+
+        with (
+            patch("supacrawl.services.pdf.is_pdf_url", return_value=True),
+            patch("supacrawl.services.pdf.download_pdf", new_callable=AsyncMock, return_value=pdf_bytes),
+        ):
+            service = ScrapeService(headless=True)
+            result = await service.scrape(
+                url="https://example.com/report.pdf",
+                formats=["markdown"],
+                parse_pdf="fast",
+            )
+
+            assert result.success is True
+            assert result.data is not None
+            assert result.data.markdown is not None
+            assert len(result.data.markdown) > 0
+            assert result.data.metadata.source_url == "https://example.com/report.pdf"
+            assert result.data.metadata.pdf_page_count is not None
+            assert result.data.metadata.pdf_page_count >= 1
+
+    @pytest.mark.asyncio
+    async def test_parse_pdf_none_uses_browser(self):
+        """When parse_pdf=None, PDF URLs should use the browser path."""
+        from supacrawl.services.scrape import ScrapeService
+
+        # If parse_pdf is None, the PDF detection is skipped entirely
+        with (
+            patch("supacrawl.services.pdf.is_pdf_url") as mock_detect,
+            patch("supacrawl.services.pdf.detect_pdf_content_type") as mock_head,
+        ):
+            service = ScrapeService(headless=True)
+            # This will fail because we haven't set up a browser, but
+            # the important thing is that PDF detection was NOT called
+            try:
+                await service.scrape(
+                    url="https://example.com/report.pdf",
+                    formats=["markdown"],
+                    parse_pdf=None,
+                )
+            except Exception:
+                pass  # Expected to fail (no browser)
+
+            mock_detect.assert_not_called()
+            mock_head.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_pdf_metadata_in_scrape_result(self):
+        """PDF metadata should be included in the ScrapeResult."""
+        from supacrawl.services.pdf import PdfExtractionResult, PdfMetadata
+        from supacrawl.services.scrape import ScrapeService
+
+        mock_result = PdfExtractionResult(
+            markdown="# Test Document\n\nSome content with enough words to be meaningful.",
+            metadata=PdfMetadata(
+                title="Test Document",
+                author="Test Author",
+                page_count=3,
+                creation_date="2024-01-15T12:00:00Z",
+            ),
+        )
+
+        with (
+            patch("supacrawl.services.pdf.is_pdf_url", return_value=True),
+            patch("supacrawl.services.pdf.parse_pdf", new_callable=AsyncMock, return_value=mock_result),
+        ):
+            service = ScrapeService(headless=True)
+            result = await service.scrape(
+                url="https://example.com/report.pdf",
+                formats=["markdown"],
+                parse_pdf="fast",
+            )
+
+            assert result.success is True
+            assert result.data.metadata.title == "Test Document"
+            assert result.data.metadata.pdf_author == "Test Author"
+            assert result.data.metadata.pdf_page_count == 3
+            assert result.data.metadata.pdf_creation_date == "2024-01-15T12:00:00Z"
+
+
+# ---------------------------------------------------------------------------
+# CLI --parse-pdf option
+# ---------------------------------------------------------------------------
+
+
+class TestCLIParsePdfOption:
+    """Test CLI --parse-pdf option resolution."""
+
+    def test_default_is_auto(self):
+        """Default parse_pdf mode should be 'auto'."""
+        # Verify the default in the CLI matches the issue spec
+        from click.testing import CliRunner
+
+        from supacrawl.cli._common import app
+
+        runner = CliRunner()
+        # Use --help to verify the option exists
+        result = runner.invoke(app, ["scrape", "--help"])
+        assert "--parse-pdf" in result.output
+        assert "auto" in result.output
+
+    def test_off_disables_pdf_parsing(self):
+        """--parse-pdf off should resolve to None."""
+        parse_pdf = "off"
+        resolved = parse_pdf if parse_pdf != "off" else None
+        assert resolved is None
+
+    def test_valid_modes(self):
+        """All valid modes should pass through."""
+        for mode in ("fast", "auto", "ocr"):
+            resolved = mode if mode != "off" else None
+            assert resolved == mode
+
+
+# ---------------------------------------------------------------------------
+# Cache variant for PDF
+# ---------------------------------------------------------------------------
+
+
+class TestPdfCacheVariant:
+    """Test that PDF results are cached correctly."""
+
+    @pytest.mark.asyncio
+    async def test_pdf_result_cached(self):
+        """PDF scrape results should be stored in cache when max_age > 0."""
+        from supacrawl.services.scrape import ScrapeService
+
+        pdf_bytes = _make_simple_pdf("A document with enough content for testing purposes and validation.")
+
+        with (
+            patch("supacrawl.services.pdf.is_pdf_url", return_value=True),
+            patch("supacrawl.services.pdf.download_pdf", new_callable=AsyncMock, return_value=pdf_bytes),
+        ):
+            import tempfile
+            from pathlib import Path
+
+            with tempfile.TemporaryDirectory() as tmpdir:
+                service = ScrapeService(headless=True, cache_dir=Path(tmpdir))
+                result = await service.scrape(
+                    url="https://example.com/report.pdf",
+                    formats=["markdown"],
+                    parse_pdf="fast",
+                    max_age=3600,
+                )
+
+                assert result.success is True
+
+                # Second call should hit cache
+                result2 = await service.scrape(
+                    url="https://example.com/report.pdf",
+                    formats=["markdown"],
+                    parse_pdf="fast",
+                    max_age=3600,
+                )
+
+                assert result2.success is True
+                assert result2.data.metadata.cache_hit is True

--- a/tests/test_search_service.py
+++ b/tests/test_search_service.py
@@ -1,7 +1,11 @@
 """Tests for search service."""
 
+from unittest.mock import AsyncMock, patch
+
+import httpx
 import pytest
 
+from supacrawl.exceptions import ProviderError
 from supacrawl.models import SearchResult, SearchResultItem, SearchSourceType
 from supacrawl.services.search import SearchService
 
@@ -241,3 +245,115 @@ class TestSearchResultItem:
         )
         assert item.markdown == "# Heading\n\nContent"
         assert item.html == "<h1>Heading</h1><p>Content</p>"
+
+
+class TestDuckDuckGoCaptchaDetection:
+    """Tests for DuckDuckGo CAPTCHA/bot detection handling."""
+
+    CAPTCHA_HTML = """
+    <html><body>
+    <div class="anomaly-modal__title">Unfortunately, bots use DuckDuckGo too.</div>
+    <div class="anomaly-modal__description">Please complete the following challenge...</div>
+    <div class="anomaly-modal__instructions">Select all squares containing a duck:</div>
+    </body></html>
+    """
+
+    NORMAL_HTML = """
+    <html><body>
+    <table>
+    <tr><td><a class="result-link" href="//duckduckgo.com/l/?uddg=https%3A%2F%2Fexample.com">Example</a></td></tr>
+    <tr><td class="result-snippet">A test snippet.</td></tr>
+    </table>
+    </body></html>
+    """
+
+    @pytest.mark.asyncio
+    async def test_captcha_http_202_raises_provider_error(self):
+        """HTTP 202 from DDG Lite should raise ProviderError."""
+        mock_response = httpx.Response(
+            status_code=202,
+            text=self.CAPTCHA_HTML,
+            request=httpx.Request("GET", "https://lite.duckduckgo.com/lite/"),
+        )
+        service = SearchService()
+        try:
+            with patch.object(service, "_get_client") as mock_get:
+                mock_client = AsyncMock()
+                mock_client.get.return_value = mock_response
+                mock_get.return_value = mock_client
+
+                with pytest.raises(ProviderError, match="CAPTCHA"):
+                    await service._search_duckduckgo("hello", 5, "test-corr")
+        finally:
+            await service.close()
+
+    @pytest.mark.asyncio
+    async def test_captcha_anomaly_modal_in_html_raises_provider_error(self):
+        """anomaly-modal in response body should raise ProviderError even with HTTP 200."""
+        mock_response = httpx.Response(
+            status_code=200,
+            text=self.CAPTCHA_HTML,
+            request=httpx.Request("GET", "https://lite.duckduckgo.com/lite/"),
+        )
+        service = SearchService()
+        try:
+            with patch.object(service, "_get_client") as mock_get:
+                mock_client = AsyncMock()
+                mock_client.get.return_value = mock_response
+                mock_get.return_value = mock_client
+
+                with pytest.raises(ProviderError, match="CAPTCHA"):
+                    await service._search_duckduckgo("hello", 5, "test-corr")
+        finally:
+            await service.close()
+
+    @pytest.mark.asyncio
+    async def test_normal_response_returns_results(self):
+        """Normal DDG response should return parsed results, not raise."""
+        mock_response = httpx.Response(
+            status_code=200,
+            text=self.NORMAL_HTML,
+            request=httpx.Request("GET", "https://lite.duckduckgo.com/lite/"),
+        )
+        service = SearchService()
+        try:
+            with patch.object(service, "_get_client") as mock_get:
+                mock_client = AsyncMock()
+                mock_client.get.return_value = mock_response
+                mock_get.return_value = mock_client
+
+                results = await service._search_duckduckgo("hello", 5, "test-corr")
+                assert len(results) == 1
+                assert results[0].url == "https://example.com"
+                assert results[0].title == "Example"
+        finally:
+            await service.close()
+
+    @pytest.mark.asyncio
+    async def test_captcha_surfaces_as_search_failure(self):
+        """CAPTCHA should surface as success=False through the search() method."""
+        mock_response = httpx.Response(
+            status_code=202,
+            text=self.CAPTCHA_HTML,
+            request=httpx.Request("GET", "https://lite.duckduckgo.com/lite/"),
+        )
+        service = SearchService()
+        try:
+            with patch.object(service, "_get_client") as mock_get:
+                mock_client = AsyncMock()
+                mock_client.get.return_value = mock_response
+                mock_get.return_value = mock_client
+
+                result = await service.search("hello", limit=5)
+                assert not result.success
+                assert result.error is not None
+                assert "CAPTCHA" in result.error
+        finally:
+            await service.close()
+
+    def test_user_agent_is_browser_like(self):
+        """HTTP client should use a browser-like User-Agent, not Supacrawl/1.0."""
+        from supacrawl.services.search import _SEARCH_USER_AGENT
+
+        assert "Supacrawl" not in _SEARCH_USER_AGENT
+        assert "Mozilla" in _SEARCH_USER_AGENT


### PR DESCRIPTION
## Summary

- Replace `Supacrawl/1.0` User-Agent with a browser-like string — no reason to announce ourselves as a bot to search engines
- Detect CAPTCHA responses (HTTP 202 or `anomaly-modal` in HTML) and raise `ProviderError` instead of silently returning empty results
- MCP consumers now receive `{success: false, error: "...CAPTCHA..."}` instead of misleading `{success: true, data: []}`

## Test plan

- [x] Unit test: HTTP 202 raises `ProviderError`
- [x] Unit test: `anomaly-modal` in HTML raises `ProviderError` (even with HTTP 200)
- [x] Unit test: Normal DDG response returns parsed results
- [x] Unit test: CAPTCHA error surfaces as `success=false` through `search()` method
- [x] Unit test: User-Agent is browser-like, not `Supacrawl/1.0`
- [x] Bisected all 16 commits since v2026.2.3 — search works at every commit (issue was rate limiting from rapid testing, not a regression)
- [x] All pre-commit hooks pass

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)