### PR TITLE
SSRF guard for crawl/scrape/screenshot with redirect pinning (#152)

### DIFF
--- a/src/supacrawl/benchmark/reference.py
+++ b/src/supacrawl/benchmark/reference.py
@@ -22,6 +22,9 @@ from typing import Any
 
 from pydantic import BaseModel
 
+from supacrawl.exceptions import ValidationError
+from supacrawl.services.url_guard import resolve_and_pin
+
 LOGGER = logging.getLogger(__name__)
 
 # Hydration-settle constants.
@@ -188,6 +191,14 @@ class ReferenceRenderer:
         """
         if self._browser is None:
             return ReferenceCapture(error="ReferenceRenderer not started — use as async context manager")
+
+        # Pre-flight SSRF check (#152), matching the other browser-navigation
+        # sites: refuse a URL that resolves to a blocked address before driving
+        # Playwright. Off the event loop — resolve_and_pin blocks on getaddrinfo.
+        try:
+            await asyncio.to_thread(resolve_and_pin, url)
+        except ValidationError as exc:
+            return ReferenceCapture(error=f"Refused by SSRF guard: {exc}")
 
         page = None
         try:

--- a/src/supacrawl/discovery/robots.py
+++ b/src/supacrawl/discovery/robots.py
@@ -11,6 +11,8 @@ from urllib.parse import urlsplit
 
 import httpx
 
+from supacrawl.services.url_guard import guarded_request
+
 LOGGER = logging.getLogger(__name__)
 
 
@@ -71,7 +73,7 @@ async def fetch_robots(base_url: str, timeout: float = 30.0) -> RobotsConfig:
 
     try:
         async with httpx.AsyncClient(timeout=timeout) as client:
-            response = await client.get(robots_url, follow_redirects=True)
+            response = await guarded_request(client, "GET", robots_url)
 
             if response.status_code == 404:
                 # 404 means no robots.txt - allow all

--- a/src/supacrawl/discovery/sitemap.py
+++ b/src/supacrawl/discovery/sitemap.py
@@ -14,6 +14,8 @@ from xml.etree import ElementTree
 
 import httpx
 
+from supacrawl.services.url_guard import guarded_request
+
 LOGGER = logging.getLogger(__name__)
 
 # Common sitemap locations to check
@@ -85,8 +87,11 @@ async def discover_sitemaps(base_url: str) -> list[str]:
     # Check robots.txt first
     robots_url = f"{origin}/robots.txt"
     try:
+        # follow_redirects left at the client default (False): redirects are
+        # followed by hand inside guarded_request so every hop is validated
+        # and pinned (#152).
         async with httpx.AsyncClient(timeout=30.0) as client:
-            response = await client.get(robots_url, follow_redirects=True)
+            response = await guarded_request(client, "GET", robots_url)
             if response.status_code == 200:
                 sitemaps.extend(_parse_robots_for_sitemaps(response.text))
                 LOGGER.debug(
@@ -103,7 +108,7 @@ async def discover_sitemaps(base_url: str) -> list[str]:
             for path in COMMON_SITEMAP_PATHS:
                 sitemap_url = f"{origin}{path}"
                 try:
-                    response = await client.head(sitemap_url, follow_redirects=True)
+                    response = await guarded_request(client, "HEAD", sitemap_url)
                     if response.status_code == 200:
                         sitemaps.append(sitemap_url)
                         LOGGER.debug("Found sitemap at %s", sitemap_url)
@@ -209,7 +214,7 @@ async def _fetch_sitemap_content(sitemap_url: str) -> bytes | None:
     """Fetch sitemap content, handling gzip compression."""
     try:
         async with httpx.AsyncClient(timeout=60.0) as client:
-            response = await client.get(sitemap_url, follow_redirects=True)
+            response = await guarded_request(client, "GET", sitemap_url)
             if response.status_code != 200:
                 LOGGER.warning(
                     "Sitemap returned status %d: %s",

--- a/src/supacrawl/mcp/tools/search.py
+++ b/src/supacrawl/mcp/tools/search.py
@@ -22,6 +22,7 @@ from supacrawl.mcp.validators import (
 )
 from supacrawl.models import SearchFilters
 from supacrawl.services.registry import SupacrawlServices
+from supacrawl.services.url_guard import guarded_request, guarded_stream
 
 
 async def _fetch_url_metadata(url: str, timeout: float = 5.0) -> dict[str, Any]:
@@ -39,18 +40,22 @@ async def _fetch_url_metadata(url: str, timeout: float = 5.0) -> dict[str, Any]:
     """
     metadata: dict[str, Any] = {}
 
+    # follow_redirects=False: redirects are followed by hand inside
+    # guarded_request/guarded_stream so every hop is validated and pinned
+    # (#152) — these URLs come straight from search results, i.e. external
+    # and not directly operator-typed.
     async with httpx.AsyncClient(
         timeout=timeout,
-        follow_redirects=True,
+        follow_redirects=False,
         headers={"User-Agent": "Mozilla/5.0 (compatible; Supacrawl/1.0)"},
     ) as client:
         try:
             # Try HEAD request first (lightweight)
-            response = await client.head(url)
+            response = await guarded_request(client, "HEAD", url)
 
             # Some servers don't support HEAD, fall back to GET with stream
             if response.status_code == 405:
-                async with client.stream("GET", url) as response:
+                async with guarded_stream(client, "GET", url) as response:
                     headers = response.headers
             else:
                 headers = response.headers

--- a/src/supacrawl/mcp/validators.py
+++ b/src/supacrawl/mcp/validators.py
@@ -12,7 +12,9 @@ from urllib.parse import urlparse
 from mcp_common.exceptions import MCPValidationError
 from mcp_common.validators import validate_positive_int as _validate_positive_int
 
+from supacrawl.exceptions import ValidationError as _SupacrawlLibValidationError
 from supacrawl.mcp.exceptions import SupacrawlValidationError
+from supacrawl.services.url_guard import assert_safe_url
 
 # Words that indicate a time-sensitive search where current year matters
 TIME_SENSITIVE_KEYWORDS = {
@@ -121,6 +123,16 @@ def validate_url(
             field=field_name,
             value=value,
         ) from e
+
+    # Cheap, offline SSRF check (#152): scheme already verified above, so this
+    # only adds the blocked-IP-literal check. It cannot catch a hostname that
+    # *resolves* to a blocked address — the connection-layer guard
+    # (supacrawl.services.url_guard.resolve_and_pin / guarded_request) is what
+    # closes that window at the point each URL is actually fetched.
+    try:
+        assert_safe_url(url)
+    except _SupacrawlLibValidationError as e:
+        raise SupacrawlValidationError(e.message, field=field_name, value=value) from e
 
     return url
 

--- a/src/supacrawl/services/browser.py
+++ b/src/supacrawl/services/browser.py
@@ -824,7 +824,8 @@ class BrowserManager:
 
         # Pre-flight SSRF check (#152): refuses now if the URL or its resolved
         # address is blocked. Not a full pin — see the Raises note above.
-        resolve_and_pin(url)
+        # Off the event loop: resolve_and_pin does a blocking getaddrinfo.
+        await asyncio.to_thread(resolve_and_pin, url)
 
         if device and self.engine == "camoufox":
             raise ValueError(
@@ -1172,7 +1173,8 @@ class BrowserManager:
             raise RuntimeError("Browser not initialized. Use 'async with BrowserManager()' context manager.")
 
         # Pre-flight SSRF check (#152): see fetch_page's Raises note.
-        resolve_and_pin(url)
+        # Off the event loop: resolve_and_pin does a blocking getaddrinfo.
+        await asyncio.to_thread(resolve_and_pin, url)
 
         context: BrowserContext | None = None
         page: Page | None = None

--- a/src/supacrawl/services/browser.py
+++ b/src/supacrawl/services/browser.py
@@ -48,6 +48,8 @@ from urllib.parse import urlparse
 
 from bs4 import BeautifulSoup
 
+from supacrawl.services.url_guard import resolve_and_pin
+
 if TYPE_CHECKING:
     from playwright.async_api import Browser, BrowserContext, Page
 
@@ -810,9 +812,19 @@ class BrowserManager:
             RuntimeError: If browser not initialized or fetch fails
             ValueError: If device is specified with Camoufox engine or device
                 name is not recognised.
+            ValidationError: If the URL or its resolved address is blocked (#152).
+                This is a pre-flight check only — the browser engine re-resolves
+                the hostname itself when it connects, so a DNS answer that
+                changes in the window between this check and the engine's own
+                connect is not pinned (see services/url_guard.py's module
+                docstring for why the browser paths cannot close that gap).
         """
         if not self._browser:
             raise RuntimeError("Browser not initialized. Use 'async with BrowserManager()' context manager.")
+
+        # Pre-flight SSRF check (#152): refuses now if the URL or its resolved
+        # address is blocked. Not a full pin — see the Raises note above.
+        resolve_and_pin(url)
 
         if device and self.engine == "camoufox":
             raise ValueError(
@@ -1153,9 +1165,14 @@ class BrowserManager:
 
         Raises:
             RuntimeError: If browser not initialized or fetch fails
+            ValidationError: If the URL or its resolved address is blocked
+                (#152); see :meth:`fetch_page` for the pre-flight-only caveat.
         """
         if not self._browser:
             raise RuntimeError("Browser not initialized. Use 'async with BrowserManager()' context manager.")
+
+        # Pre-flight SSRF check (#152): see fetch_page's Raises note.
+        resolve_and_pin(url)
 
         context: BrowserContext | None = None
         page: Page | None = None

--- a/src/supacrawl/services/diagnose.py
+++ b/src/supacrawl/services/diagnose.py
@@ -16,6 +16,7 @@ from supacrawl.services.detection import (
     estimate_js_requirement,
     generate_recommendations,
 )
+from supacrawl.services.url_guard import guarded_request
 from supacrawl.services.validation import validate_url
 
 if TYPE_CHECKING:
@@ -81,9 +82,11 @@ async def supacrawl_diagnose(
     }
 
     try:
+        # follow_redirects=False: redirects are followed by hand inside
+        # guarded_request so every hop is validated and pinned (#152).
         async with httpx.AsyncClient(
             timeout=15.0,
-            follow_redirects=True,
+            follow_redirects=False,
             headers={
                 "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
                 "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
@@ -91,7 +94,7 @@ async def supacrawl_diagnose(
             },
         ) as client:
             start_time = time.perf_counter()
-            response = await client.get(validated_url)
+            response = await guarded_request(client, "GET", validated_url)
             elapsed_ms = (time.perf_counter() - start_time) * 1000
 
             diagnosis["reachable"] = True

--- a/src/supacrawl/services/http_fetch.py
+++ b/src/supacrawl/services/http_fetch.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass, field
 import httpx
 
 from supacrawl.services._pdf_sniff import MAX_PDF_SIZE, is_pdf_bytes
+from supacrawl.services.url_guard import guarded_request
 
 LOGGER = logging.getLogger(__name__)
 
@@ -88,13 +89,16 @@ async def fetch_static(
         request_headers.update(headers)
 
     try:
+        # follow_redirects=False: redirects are followed by hand inside
+        # guarded_request so every hop — not just the first URL — is
+        # validated and pinned to the address it resolved to (#152).
         async with httpx.AsyncClient(
-            follow_redirects=True,
+            follow_redirects=False,
             timeout=httpx.Timeout(timeout_ms / 1000.0),
             proxy=proxy,
             headers=request_headers,
         ) as client:
-            response = await client.get(url)
+            response = await guarded_request(client, "GET", url)
     except Exception as e:
         # Any transport failure simply disqualifies the fast path; the browser
         # path runs next and produces the real error if it also fails.

--- a/src/supacrawl/services/map.py
+++ b/src/supacrawl/services/map.py
@@ -11,6 +11,7 @@ from bs4 import BeautifulSoup
 
 from supacrawl.models import MapEvent, MapLink, MapResult
 from supacrawl.services.browser import BrowserManager
+from supacrawl.services.url_guard import guarded_request
 
 LOGGER = logging.getLogger(__name__)
 
@@ -308,15 +309,17 @@ class MapService:
         # can be fetched.  Only header KEYS are logged; values are not.
         if headers:
             LOGGER.debug("Sitemap client using %d custom header(s): %s", len(headers), list(headers.keys()))
+        # follow_redirects=False: redirects are followed by hand inside
+        # guarded_request so every hop is validated and pinned (#152).
         async with httpx.AsyncClient(
             timeout=10.0,
-            follow_redirects=True,
+            follow_redirects=False,
             headers=headers or {},
         ) as client:
             for sitemap_url in sitemap_candidates:
                 try:
                     LOGGER.debug(f"Trying sitemap: {sitemap_url}")
-                    resp = await client.get(sitemap_url)
+                    resp = await guarded_request(client, "GET", sitemap_url)
                     if resp.status_code == 200:
                         urls.extend(await self._parse_sitemap_xml(client, resp.text))
                 except Exception as e:
@@ -344,7 +347,10 @@ class MapService:
                 if loc and loc.text:
                     try:
                         LOGGER.debug(f"Fetching nested sitemap: {loc.text}")
-                        resp = await client.get(loc.text.strip())
+                        # loc.text is attacker-influenceable (it comes from XML the
+                        # target site served us), which is exactly why this must go
+                        # through the same guard as the original request (#152).
+                        resp = await guarded_request(client, "GET", loc.text.strip())
                         if resp.status_code == 200:
                             nested_urls = await self._parse_sitemap_xml(client, resp.text)
                             urls.extend(nested_urls)

--- a/src/supacrawl/services/pdf.py
+++ b/src/supacrawl/services/pdf.py
@@ -20,6 +20,7 @@ from urllib.parse import urlparse
 import httpx
 
 from supacrawl.services._pdf_sniff import MAX_PDF_SIZE, is_pdf_bytes
+from supacrawl.services.url_guard import guarded_request
 
 LOGGER = logging.getLogger(__name__)
 
@@ -152,12 +153,14 @@ async def detect_pdf_content_type(url: str, timeout: float = 10.0) -> bool:
     Returns False on any network error rather than raising.
     """
     try:
+        # follow_redirects=False: redirects are followed by hand inside
+        # guarded_request so every hop is validated and pinned (#152).
         async with httpx.AsyncClient(
             timeout=timeout,
-            follow_redirects=True,
+            follow_redirects=False,
             headers={"User-Agent": "Mozilla/5.0 (compatible; supacrawl)"},
         ) as client:
-            response = await client.head(url)
+            response = await guarded_request(client, "HEAD", url)
             content_type = response.headers.get("content-type", "")
             return "application/pdf" in content_type.lower()
     except Exception:
@@ -178,14 +181,17 @@ async def download_pdf(url: str, timeout: float = 120.0, max_size: int = MAX_PDF
     Raises:
         httpx.HTTPStatusError: If the server returns a non-2xx status.
         httpx.TimeoutException: If the request times out.
+        ValidationError: If the URL or a redirect hop fails the SSRF guard (#152).
         ValueError: If the PDF exceeds *max_size* bytes.
     """
+    # follow_redirects=False: redirects are followed by hand inside
+    # guarded_request so every hop is validated and pinned (#152).
     async with httpx.AsyncClient(
         timeout=timeout,
-        follow_redirects=True,
+        follow_redirects=False,
         headers={"User-Agent": "Mozilla/5.0 (compatible; supacrawl)"},
     ) as client:
-        response = await client.get(url)
+        response = await guarded_request(client, "GET", url)
         response.raise_for_status()
 
         if len(response.content) > max_size:

--- a/src/supacrawl/services/scrape.py
+++ b/src/supacrawl/services/scrape.py
@@ -2529,6 +2529,8 @@ class ScrapeService:
                 pre-flight-only caveat (this path navigates its own ad-hoc
                 page rather than going through ``fetch_page``).
         """
+        import asyncio
+
         from supacrawl.services.captcha import (
             CaptchaSolver,
             CaptchaSolverError,
@@ -2537,7 +2539,8 @@ class ScrapeService:
 
         # Pre-flight SSRF check (#152): this method drives its own page.goto
         # rather than BrowserManager.fetch_page, so it needs its own check.
-        resolve_and_pin(url)
+        # Off the event loop: resolve_and_pin does a blocking getaddrinfo.
+        await asyncio.to_thread(resolve_and_pin, url)
 
         # Create browser context for CAPTCHA solving
         browser = BrowserManager(

--- a/src/supacrawl/services/scrape.py
+++ b/src/supacrawl/services/scrape.py
@@ -2522,11 +2522,22 @@ class ScrapeService:
 
         Returns:
             ScrapeResult if successful, None if CAPTCHA solving failed
+
+        Raises:
+            ValidationError: If the URL or its resolved address is blocked
+                (#152); see ``BrowserManager.fetch_page``'s docstring for the
+                pre-flight-only caveat (this path navigates its own ad-hoc
+                page rather than going through ``fetch_page``).
         """
         from supacrawl.services.captcha import (
             CaptchaSolver,
             CaptchaSolverError,
         )
+        from supacrawl.services.url_guard import resolve_and_pin
+
+        # Pre-flight SSRF check (#152): this method drives its own page.goto
+        # rather than BrowserManager.fetch_page, so it needs its own check.
+        resolve_and_pin(url)
 
         # Create browser context for CAPTCHA solving
         browser = BrowserManager(

--- a/src/supacrawl/services/url_guard.py
+++ b/src/supacrawl/services/url_guard.py
@@ -54,6 +54,7 @@ controls.
 
 from __future__ import annotations
 
+import asyncio
 import ipaddress
 import os
 import socket
@@ -88,6 +89,12 @@ _PRIVATE_NETWORKS: tuple[IPNetwork, ...] = (
     ipaddress.IPv6Network("fc00::/7"),  # IPv6 unique-local
 )
 
+# The well-known NAT64 prefix (RFC 6052): a 64:ff9b::/96 address embeds a
+# routable IPv4 destination in its low 32 bits. IPv4-mapped and 6to4 forms have
+# stdlib accessors (``.ipv4_mapped`` / ``.sixtofour``); NAT64 does not, so it is
+# matched explicitly and the embedded IPv4 pulled out by hand.
+_NAT64_PREFIX = ipaddress.IPv6Network("64:ff9b::/96")
+
 _ALLOWED_SCHEMES = {"http", "https"}
 
 _STRICT_ENV = "SUPACRAWL_BLOCK_PRIVATE_NETWORKS"
@@ -115,9 +122,38 @@ def _blocked_networks() -> tuple[IPNetwork, ...]:
     return _BLOCKED_NETWORKS
 
 
+def _candidate_addresses(addr: IPAddress) -> list[IPAddress]:
+    """The address plus any IPv4 destination it embeds and would route to.
+
+    An IPv6 literal can carry a blocked IPv4 target that a dual-stack host
+    connects to directly: IPv4-mapped (``::ffff:169.254.169.254``), 6to4
+    (``2002::/16``), or NAT64 (``64:ff9b::/96``). Classifying only the outer
+    IPv6 form misses the embedded target — an IPv6 address is never ``in`` an
+    IPv4 network, so ``::ffff:169.254.169.254`` slips past every IPv4 blocklist
+    entry (SSRF, #152). Checking the embedded IPv4 as well closes that.
+
+    Args:
+        addr: A parsed IP address.
+
+    Returns:
+        ``[addr]`` for a plain address; ``[addr, embedded_ipv4]`` when *addr* is
+        an IPv6 form that embeds an IPv4 destination.
+    """
+    candidates: list[IPAddress] = [addr]
+    if isinstance(addr, ipaddress.IPv6Address):
+        embedded = addr.ipv4_mapped
+        if embedded is None:
+            embedded = addr.sixtofour
+        if embedded is None and addr in _NAT64_PREFIX:
+            embedded = ipaddress.IPv4Address(int(addr) & 0xFFFFFFFF)
+        if embedded is not None:
+            candidates.append(embedded)
+    return candidates
+
+
 def _describe(addr: IPAddress) -> str:
     """A short reason an address is refused, for the error message."""
-    if any(addr in net for net in _BLOCKED_NETWORKS):
+    if any(c in net for c in _candidate_addresses(addr) for net in _BLOCKED_NETWORKS):
         return "link-local / cloud-metadata"
     return "private / loopback"
 
@@ -125,13 +161,17 @@ def _describe(addr: IPAddress) -> str:
 def is_blocked_address(addr: IPAddress) -> bool:
     """Whether *addr* falls in a range refused under the current policy.
 
+    An IPv4-mapped/6to4/NAT64 IPv6 form is classified by the IPv4 destination it
+    embeds as well as by its own value, so a blocked IPv4 target cannot be
+    smuggled past the guard wearing an IPv6 spelling (#152).
+
     Args:
         addr: A parsed IP address.
 
     Returns:
         True when the address must not be connected to.
     """
-    return any(addr in net for net in _blocked_networks())
+    return any(c in net for c in _candidate_addresses(addr) for net in _blocked_networks())
 
 
 def _is_blocked_ip(host: str) -> bool:
@@ -278,6 +318,24 @@ def pinned_url(url: str, address: str) -> str:
     return urlunparse(parsed._replace(netloc=netloc))
 
 
+def _authority(host: str, port: int | None) -> str:
+    """The value for the ``Host`` header: the real hostname, port preserved.
+
+    Connecting to a pinned IP literal means httpx will not derive ``Host`` from
+    the request URL, so it is set by hand. RFC 7230 §5.4 requires the authority
+    to carry a non-default port, and an IPv6 hostname literal to be bracketed.
+
+    Args:
+        host: The original hostname (unbracketed, no port).
+        port: The explicit port from the URL, or ``None`` for the scheme default.
+
+    Returns:
+        The ``Host`` header value.
+    """
+    literal = f"[{host}]" if ":" in host else host
+    return f"{literal}:{port}" if port is not None else literal
+
+
 @asynccontextmanager
 async def guarded_stream(
     client: httpx.AsyncClient,
@@ -313,16 +371,19 @@ async def guarded_stream(
     """
     current_url = url
     for _ in range(max_redirects + 1):
-        address, host = resolve_and_pin(current_url)
+        # resolve_and_pin does a blocking socket.getaddrinfo; run it off the
+        # event loop so a slow resolver does not stall other concurrent fetches
+        # (httpx's own resolution is threaded for the same reason).
+        address, host = await asyncio.to_thread(resolve_and_pin, current_url)
         request_url = pinned_url(current_url, address)
 
         # The connection goes to the pinned address, but the server still needs
-        # the real hostname: Host for virtual hosting, SNI so TLS presents and
-        # verifies the right certificate.
+        # the real hostname: Host (with any non-default port) for virtual
+        # hosting, SNI so TLS presents and verifies the right certificate.
         request = client.build_request(
             method,
             request_url,
-            headers={"Host": host},
+            headers={"Host": _authority(host, urlparse(current_url).port)},
             extensions={"sni_hostname": host},
         )
         response = await client.send(request, stream=True, follow_redirects=False)

--- a/src/supacrawl/services/url_guard.py
+++ b/src/supacrawl/services/url_guard.py
@@ -1,0 +1,378 @@
+"""Outbound URL safety guard (SSRF hardening, #152).
+
+Supacrawl fetches whatever URL a caller — or a page it has already fetched —
+hands it: scrape/crawl/map targets, PDF downloads, sitemap and robots.txt
+lookups, search-result metadata probes. None of that previously checked
+whether the target resolves to an internal address, so a hostname pointing at
+cloud instance metadata (``169.254.169.254``) or a link-local address was
+fetched without complaint, and a redirect could pivot to one mid-request.
+
+Two failure modes are closed here:
+
+1. **No resolved-address check at all.** A URL whose hostname resolves to a
+   blocked range is refused. Checking IP literals in the URL is not enough —
+   owning a DNS record that resolves to the metadata endpoint defeats that.
+2. **No pinning, so a time-of-check/time-of-use gap.** Even with a check, a
+   hostname validated as public could rebind to an internal address before
+   the connection is made, unless the validated address is what gets
+   connected to. :func:`resolve_and_pin` closes that window for the httpx
+   fast path; :func:`guarded_request` / :func:`guarded_stream` are the call
+   sites that actually connect to the pinned address.
+
+Redirects get the same treatment per hop via :func:`guarded_request` /
+:func:`guarded_stream`: a 3xx pivot to an internal address is the same attack
+wearing a hat.
+
+**Residual exposure — the browser engines (Playwright/Patchright/Camoufox).**
+Those engines own their own network stack; there is no supported API to hand
+Chromium or Firefox a pre-resolved literal address while it still presents
+the original hostname for TLS SNI and virtual hosting the way httpx's
+``extensions={"sni_hostname": ...}`` does. The browser call sites
+(``BrowserManager.fetch_page`` / ``extract_links``,
+``ScrapeService._scrape_with_captcha_solving``) call :func:`resolve_and_pin`
+as a pre-flight — refusing a URL that resolves to a blocked address right
+now — but the browser then re-resolves the hostname itself when it actually
+connects, so a DNS answer that changes in that window is not pinned. This is
+a real, accepted gap: closing it would mean routing all browser traffic
+through a local proxy that itself pins addresses, which is out of scope
+here. Documented rather than silently left open, per the household's "an
+honest 'this path cannot be pinned, here is why' is a legitimate outcome"
+standard.
+
+RFC 1918 private ranges and loopback are **not** blocked by default:
+operators legitimately point supacrawl at internal documentation sites,
+which is a first-class use case for a self-hosted tool. A consumer that
+accepts untrusted URLs (a multi-user app letting users add their own
+sources) needs the stricter posture and can set
+``SUPACRAWL_BLOCK_PRIVATE_NETWORKS=1`` to refuse internal targets outright.
+This mirrors ragify's ``RAGIFY_BLOCK_PRIVATE_NETWORKS`` switch (see
+poodle64/ragify's ``url_guard.py``) so the two libraries agree on the same
+policy shape. The guard is a policy layer, not a network firewall; operators
+who need guaranteed SSRF containment should also use network egress
+controls.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import os
+import socket
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from urllib.parse import urljoin, urlparse, urlunparse
+
+import httpx
+
+from supacrawl.exceptions import ValidationError
+
+type IPNetwork = ipaddress.IPv4Network | ipaddress.IPv6Network
+type IPAddress = ipaddress.IPv4Address | ipaddress.IPv6Address
+
+# Cloud metadata / link-local ranges that must never be fetch targets. Nobody
+# legitimately scrapes an instance metadata endpoint.
+_BLOCKED_NETWORKS: tuple[IPNetwork, ...] = (
+    ipaddress.IPv4Network("169.254.0.0/16"),  # Link-local / AWS/GCP/Azure IMDS
+    ipaddress.IPv6Network("fe80::/10"),  # IPv6 link-local
+)
+
+# Additionally blocked when SUPACRAWL_BLOCK_PRIVATE_NETWORKS is set: everything
+# an untrusted URL could use to reach the host or its network.
+_PRIVATE_NETWORKS: tuple[IPNetwork, ...] = (
+    ipaddress.IPv4Network("10.0.0.0/8"),
+    ipaddress.IPv4Network("172.16.0.0/12"),
+    ipaddress.IPv4Network("192.168.0.0/16"),
+    ipaddress.IPv4Network("127.0.0.0/8"),  # Loopback
+    ipaddress.IPv4Network("0.0.0.0/8"),  # "This host on this network"
+    ipaddress.IPv4Network("100.64.0.0/10"),  # Carrier-grade NAT
+    ipaddress.IPv6Network("::1/128"),  # IPv6 loopback
+    ipaddress.IPv6Network("fc00::/7"),  # IPv6 unique-local
+)
+
+_ALLOWED_SCHEMES = {"http", "https"}
+
+_STRICT_ENV = "SUPACRAWL_BLOCK_PRIVATE_NETWORKS"
+
+# Redirect hops followed by guarded_request/guarded_stream before giving up.
+MAX_REDIRECTS = 10
+
+
+def _strict_mode() -> bool:
+    """Whether private and loopback ranges are blocked as well.
+
+    Read at call time rather than import time so a consumer can set it during
+    application startup without import-order mattering.
+
+    Returns:
+        True when ``SUPACRAWL_BLOCK_PRIVATE_NETWORKS`` is set to a truthy value.
+    """
+    return os.environ.get(_STRICT_ENV, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _blocked_networks() -> tuple[IPNetwork, ...]:
+    """The networks refused under the current policy."""
+    if _strict_mode():
+        return _BLOCKED_NETWORKS + _PRIVATE_NETWORKS
+    return _BLOCKED_NETWORKS
+
+
+def _describe(addr: IPAddress) -> str:
+    """A short reason an address is refused, for the error message."""
+    if any(addr in net for net in _BLOCKED_NETWORKS):
+        return "link-local / cloud-metadata"
+    return "private / loopback"
+
+
+def is_blocked_address(addr: IPAddress) -> bool:
+    """Whether *addr* falls in a range refused under the current policy.
+
+    Args:
+        addr: A parsed IP address.
+
+    Returns:
+        True when the address must not be connected to.
+    """
+    return any(addr in net for net in _blocked_networks())
+
+
+def _is_blocked_ip(host: str) -> bool:
+    """Whether *host* is an IP literal in a blocked range.
+
+    Non-IP hostnames return False; they are checked after resolution by
+    :func:`resolve_and_pin`.
+
+    Args:
+        host: A hostname or IP literal.
+
+    Returns:
+        True when the host is a blocked IP literal.
+    """
+    try:
+        addr = ipaddress.ip_address(host)
+    except ValueError:
+        return False
+    return is_blocked_address(addr)
+
+
+def assert_safe_url(url: str) -> None:
+    """Raise when *url* is not safe for outbound fetching, without resolving it.
+
+    The cheap, offline half of the guard: scheme and IP-literal checks only. It
+    cannot catch a hostname that resolves to a blocked address; use
+    :func:`resolve_and_pin` where the connection is actually made.
+
+    Args:
+        url: The URL to validate.
+
+    Raises:
+        ValidationError: When the scheme is not http(s), or the host is a
+            blocked IP literal.
+    """
+    parsed = urlparse(url)
+    scheme = parsed.scheme.lower()
+    if scheme not in _ALLOWED_SCHEMES:
+        raise ValidationError(
+            f"URL scheme {scheme!r} is not allowed for outbound requests; only http and https are permitted.",
+            field="url",
+            value=url,
+        )
+    host = parsed.hostname or ""
+    if _is_blocked_ip(host):
+        raise ValidationError(
+            f"URL host {host!r} is in a blocked IP range ({_describe(ipaddress.ip_address(host))}).",
+            field="url",
+            value=url,
+        )
+
+
+def _resolve(host: str, port: int) -> list[IPAddress]:
+    """Resolve *host* to every address it currently answers with.
+
+    Args:
+        host: Hostname or IP literal.
+        port: Port, which steers getaddrinfo's service resolution.
+
+    Returns:
+        The resolved addresses, in the order the resolver returned them.
+
+    Raises:
+        ValidationError: When the host cannot be resolved.
+    """
+    try:
+        infos = socket.getaddrinfo(host, port, proto=socket.IPPROTO_TCP)
+    except socket.gaierror as exc:
+        raise ValidationError(f"Cannot resolve host {host!r}: {exc}", field="url", value=host) from exc
+
+    addresses: list[IPAddress] = []
+    for info in infos:
+        sockaddr = info[4]
+        try:
+            addr = ipaddress.ip_address(sockaddr[0])
+        except ValueError:
+            continue
+        if addr not in addresses:
+            addresses.append(addr)
+
+    if not addresses:
+        raise ValidationError(f"Host {host!r} resolved to no usable address", field="url", value=host)
+    return addresses
+
+
+def resolve_and_pin(url: str) -> tuple[str, str]:
+    """Validate *url*, resolve it, and return an address safe to connect to.
+
+    This is the half of the guard that closes the rebinding window. It resolves
+    the hostname once and refuses the fetch if **any** returned address is
+    blocked, rather than hunting for one that passes: a name answering with both
+    a public and an internal address is a rebinding attack, not a fallback list.
+    The caller connects to the returned address literally, so the DNS answer
+    cannot change between this check and the connection.
+
+    Args:
+        url: The URL about to be fetched.
+
+    Returns:
+        Tuple of (pinned address, host) — the address to connect to, and the
+        original hostname the caller must still send as ``Host`` and SNI so
+        virtual hosting and certificate validation keep working.
+
+    Raises:
+        ValidationError: When the scheme is disallowed, the host cannot be
+            resolved, or any resolved address is in a blocked range.
+    """
+    assert_safe_url(url)
+
+    parsed = urlparse(url)
+    host = parsed.hostname or ""
+    if not host:
+        raise ValidationError(f"URL has no host: {url!r}", field="url", value=url)
+
+    port = parsed.port or (443 if parsed.scheme.lower() == "https" else 80)
+    addresses = _resolve(host, port)
+
+    for addr in addresses:
+        if is_blocked_address(addr):
+            raise ValidationError(
+                f"URL host {host!r} resolves to {addr}, which is in a blocked range ({_describe(addr)}).",
+                field="url",
+                value=url,
+            )
+
+    return str(addresses[0]), host
+
+
+def pinned_url(url: str, address: str) -> str:
+    """Rewrite *url* to connect to *address* while keeping its path and query.
+
+    An IPv6 literal is bracketed so the authority stays parseable.
+
+    Args:
+        url: The original URL.
+        address: The pinned IP address to connect to.
+
+    Returns:
+        The URL with its host replaced by the pinned address.
+    """
+    parsed = urlparse(url)
+    literal = f"[{address}]" if ":" in address else address
+    netloc = f"{literal}:{parsed.port}" if parsed.port else literal
+    return urlunparse(parsed._replace(netloc=netloc))
+
+
+@asynccontextmanager
+async def guarded_stream(
+    client: httpx.AsyncClient,
+    method: str,
+    url: str,
+    *,
+    max_redirects: int = MAX_REDIRECTS,
+) -> AsyncIterator[httpx.Response]:
+    """Open a streaming request for *url*, pinning every hop to a validated address.
+
+    Each hop is resolved once, checked, and connected to by literal address, so a
+    DNS record cannot rebind to an internal target between the check and the
+    socket. Redirects are followed by hand, at most *max_redirects* deep, so
+    every hop passes the same guard: a 3xx pivot to the metadata endpoint is
+    refused like a direct request to it.
+
+    Args:
+        client: The client to issue requests on. Its own default headers
+            (User-Agent, Accept, etc. set at construction) still apply; this
+            only overrides the connection target and Host/SNI per hop. Must
+            not itself be configured with ``follow_redirects=True`` — that
+            would let a hop through unguarded.
+        method: HTTP method, e.g. "GET" or "HEAD".
+        url: The URL to fetch.
+        max_redirects: Maximum redirect hops to follow before giving up.
+
+    Yields:
+        The final non-redirect response, still streaming (call ``.aread()`` if
+        the buffered body is needed).
+
+    Raises:
+        ValidationError: When any hop fails validation or the chain is too deep.
+    """
+    current_url = url
+    for _ in range(max_redirects + 1):
+        address, host = resolve_and_pin(current_url)
+        request_url = pinned_url(current_url, address)
+
+        # The connection goes to the pinned address, but the server still needs
+        # the real hostname: Host for virtual hosting, SNI so TLS presents and
+        # verifies the right certificate.
+        request = client.build_request(
+            method,
+            request_url,
+            headers={"Host": host},
+            extensions={"sni_hostname": host},
+        )
+        response = await client.send(request, stream=True, follow_redirects=False)
+
+        if not response.is_redirect:
+            try:
+                yield response
+            finally:
+                await response.aclose()
+            return
+
+        location = response.headers.get("location")
+        await response.aclose()
+        if not location:
+            raise ValidationError(f"Redirect from {current_url!r} carried no Location header", field="url", value=url)
+        # Resolve against the logical URL, not the pinned one: a relative
+        # Location off a pinned-IP request URL would silently drop the
+        # hostname and with it the vhost/certificate identity.
+        current_url = urljoin(current_url, location)
+
+    raise ValidationError(f"Too many redirects (>{max_redirects}) starting from {url!r}", field="url", value=url)
+
+
+async def guarded_request(
+    client: httpx.AsyncClient,
+    method: str,
+    url: str,
+    *,
+    max_redirects: int = MAX_REDIRECTS,
+) -> httpx.Response:
+    """Issue a fully-read request whose every hop is pinned (see :func:`guarded_stream`).
+
+    A thin buffering wrapper for the common case where a caller wants
+    ``.text``/``.content``/``.json()`` available on the returned response,
+    exactly like ``client.get()``/``client.head()``, but with every hop
+    validated and pinned instead of ``follow_redirects=True`` blindly trusting
+    the chain.
+
+    Args:
+        client: The client to issue requests on (see :func:`guarded_stream`).
+        method: HTTP method, e.g. "GET" or "HEAD".
+        url: The URL to fetch.
+        max_redirects: Maximum redirect hops to follow before giving up.
+
+    Returns:
+        The final, already-read response.
+
+    Raises:
+        ValidationError: When any hop fails validation or the chain is too deep.
+    """
+    async with guarded_stream(client, method, url, max_redirects=max_redirects) as response:
+        await response.aread()
+        return response

--- a/src/supacrawl/services/url_guard.py
+++ b/src/supacrawl/services/url_guard.py
@@ -91,9 +91,15 @@ _PRIVATE_NETWORKS: tuple[IPNetwork, ...] = (
 
 # The well-known NAT64 prefix (RFC 6052): a 64:ff9b::/96 address embeds a
 # routable IPv4 destination in its low 32 bits. IPv4-mapped and 6to4 forms have
-# stdlib accessors (``.ipv4_mapped`` / ``.sixtofour``); NAT64 does not, so it is
-# matched explicitly and the embedded IPv4 pulled out by hand.
+# stdlib accessors (``.ipv4_mapped`` / ``.sixtofour``); NAT64 and the deprecated
+# IPv4-compatible form (``::a.b.c.d``, RFC 4291) do not, so they are matched by
+# prefix and the embedded IPv4 pulled out by hand.
 _NAT64_PREFIX = ipaddress.IPv6Network("64:ff9b::/96")
+_IPV4_COMPAT_PREFIX = ipaddress.IPv6Network("::/96")
+# ``::`` (unspecified) and ``::1`` (loopback) sit inside ::/96 but are genuine
+# IPv6 special addresses, not IPv4-compatible destinations — do not treat their
+# low 32 bits as an embedded IPv4.
+_IPV6_SPECIAL = frozenset({ipaddress.IPv6Address("::"), ipaddress.IPv6Address("::1")})
 
 _ALLOWED_SCHEMES = {"http", "https"}
 
@@ -127,10 +133,18 @@ def _candidate_addresses(addr: IPAddress) -> list[IPAddress]:
 
     An IPv6 literal can carry a blocked IPv4 target that a dual-stack host
     connects to directly: IPv4-mapped (``::ffff:169.254.169.254``), 6to4
-    (``2002::/16``), or NAT64 (``64:ff9b::/96``). Classifying only the outer
-    IPv6 form misses the embedded target — an IPv6 address is never ``in`` an
-    IPv4 network, so ``::ffff:169.254.169.254`` slips past every IPv4 blocklist
-    entry (SSRF, #152). Checking the embedded IPv4 as well closes that.
+    (``2002::/16``), NAT64 (``64:ff9b::/96``), or the deprecated IPv4-compatible
+    form (``::169.254.169.254``). Classifying only the outer IPv6 form misses the
+    embedded target — an IPv6 address is never ``in`` an IPv4 network, so
+    ``::ffff:169.254.169.254`` slips past every IPv4 blocklist entry (SSRF,
+    #152). Checking the embedded IPv4 as well closes every destination-embedding
+    form.
+
+    Teredo (``2001::/32``) is deliberately not covered: its embedded IPv4 is the
+    Teredo *server*, not the destination, so it is not a destination-embedding
+    form, and no supported OS (NixOS / macOS / Linux) enables the automatic
+    tunnelling that would make such a literal route to the embedded IPv4 anyway.
+    It is an accepted residual rather than a silent gap.
 
     Args:
         addr: A parsed IP address.
@@ -145,6 +159,8 @@ def _candidate_addresses(addr: IPAddress) -> list[IPAddress]:
         if embedded is None:
             embedded = addr.sixtofour
         if embedded is None and addr in _NAT64_PREFIX:
+            embedded = ipaddress.IPv4Address(int(addr) & 0xFFFFFFFF)
+        if embedded is None and addr in _IPV4_COMPAT_PREFIX and addr not in _IPV6_SPECIAL:
             embedded = ipaddress.IPv4Address(int(addr) & 0xFFFFFFFF)
         if embedded is not None:
             candidates.append(embedded)

--- a/src/supacrawl/services/url_guard.py
+++ b/src/supacrawl/services/url_guard.py
@@ -220,9 +220,26 @@ def assert_safe_url(url: str) -> None:
         url: The URL to validate.
 
     Raises:
-        ValidationError: When the scheme is not http(s), or the host is a
-            blocked IP literal.
+        ValidationError: When the URL contains a parser-divergence character,
+            the scheme is not http(s), or the host is a blocked IP literal.
     """
+    # Reject characters that RFC 3986 requires to be percent-encoded but that
+    # WHATWG-URL browser engines strip or remap: a backslash (Chromium treats it
+    # as "/" in the authority) and raw ASCII control characters (tab/newline/CR
+    # are stripped before parsing). urllib.parse and a browser then disagree on
+    # which host the URL names, so the browser pre-flight would validate one host
+    # while the engine navigates to another — a deterministic SSRF bypass (#152,
+    # e.g. http://169.254.169.254\@allowed-host/). A well-formed URL never
+    # carries these raw; a legitimately-intended one survives percent-encoded.
+    bad = next((c for c in url if c == "\\" or ord(c) < 0x20 or ord(c) == 0x7F), None)
+    if bad is not None:
+        raise ValidationError(
+            f"URL contains character {bad!r}, which browser and RFC 3986 parsers interpret "
+            "differently; percent-encode it. Raw backslashes and control characters are not allowed.",
+            field="url",
+            value=url,
+        )
+
     parsed = urlparse(url)
     scheme = parsed.scheme.lower()
     if scheme not in _ALLOWED_SCHEMES:

--- a/src/supacrawl/services/validation.py
+++ b/src/supacrawl/services/validation.py
@@ -11,6 +11,7 @@ from typing import Any
 from urllib.parse import urlparse
 
 from supacrawl.exceptions import ValidationError
+from supacrawl.services.url_guard import assert_safe_url
 
 
 def validate_url(
@@ -85,6 +86,16 @@ def validate_url(
             field=field_name,
             value=value,
         )
+
+    # Cheap, offline SSRF check (#152): scheme already verified above, so this
+    # only adds the blocked-IP-literal check. It cannot catch a hostname that
+    # *resolves* to a blocked address — the connection-layer guard
+    # (supacrawl.services.url_guard.resolve_and_pin / guarded_request) is what
+    # closes that window at the point each URL is actually fetched.
+    try:
+        assert_safe_url(url)
+    except ValidationError as e:
+        raise ValidationError(e.message, field=field_name, value=value, context=e.context) from e
 
     return url
 

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -391,3 +391,52 @@ class TestBrowserManager:
             assert isinstance(images, list)
             assert len(images) == 1
             assert "https://example.com/real-image.jpg" in images
+
+
+class TestBrowserPreflightSSRF:
+    """The #152 pre-flight refuses a blocked URL before any browser is driven.
+
+    ``_browser`` is set to a sentinel so the "not initialised" guard passes
+    without launching Playwright; ``resolve_and_pin`` is patched to refuse, and
+    the refusal must propagate before the sentinel is ever used.
+    """
+
+    @pytest.mark.asyncio
+    async def test_fetch_page_refuses_blocked_url_before_launch(self, monkeypatch):
+        from supacrawl.exceptions import ValidationError
+        from supacrawl.services import browser as browser_mod
+
+        manager = browser_mod.BrowserManager()
+        monkeypatch.setattr(manager, "_browser", object())
+
+        def refuse(url):
+            raise ValidationError(
+                "URL host resolves to 169.254.169.254, which is in a blocked range",
+                field="url",
+                value=url,
+            )
+
+        monkeypatch.setattr(browser_mod, "resolve_and_pin", refuse)
+
+        with pytest.raises(ValidationError, match="blocked"):
+            await manager.fetch_page("http://evil.example.com/")
+
+    @pytest.mark.asyncio
+    async def test_extract_links_refuses_blocked_url_before_launch(self, monkeypatch):
+        from supacrawl.exceptions import ValidationError
+        from supacrawl.services import browser as browser_mod
+
+        manager = browser_mod.BrowserManager()
+        monkeypatch.setattr(manager, "_browser", object())
+
+        def refuse(url):
+            raise ValidationError(
+                "URL host resolves to a blocked range (link-local / cloud-metadata)",
+                field="url",
+                value=url,
+            )
+
+        monkeypatch.setattr(browser_mod, "resolve_and_pin", refuse)
+
+        with pytest.raises(ValidationError, match="blocked"):
+            await manager.extract_links("http://evil.example.com/")

--- a/tests/test_http_first.py
+++ b/tests/test_http_first.py
@@ -356,16 +356,16 @@ class TestFetchStatic:
         return resp
 
     async def _call(self, fake_response: MagicMock) -> HttpFetchResult | None:
-        """Call fetch_static with a patched httpx.AsyncClient."""
+        """Call fetch_static with a patched guarded_request (#152).
+
+        fetch_static routes its GET through url_guard.guarded_request rather
+        than calling client.get() directly, so the fake response is injected
+        there; the real httpx.AsyncClient is left to construct normally since
+        it never actually opens a socket in this path.
+        """
         from supacrawl.services.http_fetch import fetch_static
 
-        mock_client = AsyncMock()
-        mock_client.get = AsyncMock(return_value=fake_response)
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        # False matches httpx's real __aexit__ — it does not suppress exceptions.
-        mock_client.__aexit__ = AsyncMock(return_value=False)
-
-        with patch("supacrawl.services.http_fetch.httpx.AsyncClient", return_value=mock_client):
+        with patch("supacrawl.services.http_fetch.guarded_request", AsyncMock(return_value=fake_response)):
             return await fetch_static("https://example.com/doc", timeout_ms=5000)
 
     async def test_missing_content_type_with_pdf_magic_routed_to_pdf(self) -> None:

--- a/tests/test_mcp/test_validators.py
+++ b/tests/test_mcp/test_validators.py
@@ -62,6 +62,22 @@ class TestValidateUrl:
             validate_url("ftp://example.com")
         assert "http" in str(exc_info.value).lower()
 
+    def test_rejects_cloud_metadata_ip(self):
+        """The MCP argument validator refuses a link-local/metadata IP literal (#152)."""
+        with pytest.raises(SupacrawlValidationError) as exc_info:
+            validate_url("http://169.254.169.254/latest/meta-data/")
+        assert "blocked" in str(exc_info.value).lower()
+
+    def test_rejects_ipv4_mapped_metadata_ip(self):
+        """The IPv4-mapped IPv6 spelling of the metadata endpoint is refused too (#152)."""
+        with pytest.raises(SupacrawlValidationError) as exc_info:
+            validate_url("http://[::ffff:169.254.169.254]/latest/meta-data/")
+        assert "blocked" in str(exc_info.value).lower()
+
+    def test_allows_public_url(self):
+        """A normal public URL passes the SSRF pre-check unchanged."""
+        assert validate_url("https://docs.example.com/guide") == "https://docs.example.com/guide"
+
 
 class TestValidateQuery:
     """Test search query validation."""

--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -154,18 +154,15 @@ class TestDetectPdfContentType:
 
     @pytest.mark.asyncio
     async def test_detects_pdf_content_type(self):
+        """detect_pdf_content_type routes its HEAD through url_guard.guarded_request
+        (#152) rather than calling client.head() directly, so the fake response
+        is injected there."""
         from supacrawl.services.pdf import detect_pdf_content_type
 
         mock_response = MagicMock()
         mock_response.headers = {"content-type": "application/pdf"}
 
-        with patch("supacrawl.services.pdf.httpx.AsyncClient") as mock_client_cls:
-            mock_client = AsyncMock()
-            mock_client.head = AsyncMock(return_value=mock_response)
-            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-            mock_client.__aexit__ = AsyncMock(return_value=None)
-            mock_client_cls.return_value = mock_client
-
+        with patch("supacrawl.services.pdf.guarded_request", AsyncMock(return_value=mock_response)):
             result = await detect_pdf_content_type("https://example.com/report")
             assert result is True
 
@@ -176,13 +173,7 @@ class TestDetectPdfContentType:
         mock_response = MagicMock()
         mock_response.headers = {"content-type": "text/html; charset=utf-8"}
 
-        with patch("supacrawl.services.pdf.httpx.AsyncClient") as mock_client_cls:
-            mock_client = AsyncMock()
-            mock_client.head = AsyncMock(return_value=mock_response)
-            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-            mock_client.__aexit__ = AsyncMock(return_value=None)
-            mock_client_cls.return_value = mock_client
-
+        with patch("supacrawl.services.pdf.guarded_request", AsyncMock(return_value=mock_response)):
             result = await detect_pdf_content_type("https://example.com/page")
             assert result is False
 
@@ -190,13 +181,10 @@ class TestDetectPdfContentType:
     async def test_network_error_returns_false(self):
         from supacrawl.services.pdf import detect_pdf_content_type
 
-        with patch("supacrawl.services.pdf.httpx.AsyncClient") as mock_client_cls:
-            mock_client = AsyncMock()
-            mock_client.head = AsyncMock(side_effect=Exception("Connection refused"))
-            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-            mock_client.__aexit__ = AsyncMock(return_value=None)
-            mock_client_cls.return_value = mock_client
-
+        with patch(
+            "supacrawl.services.pdf.guarded_request",
+            AsyncMock(side_effect=Exception("Connection refused")),
+        ):
             result = await detect_pdf_content_type("https://unreachable.com/file")
             assert result is False
 
@@ -249,6 +237,9 @@ class TestPdfSizeLimit:
 
     @pytest.mark.asyncio
     async def test_oversized_pdf_raises_value_error(self):
+        """download_pdf routes its GET through url_guard.guarded_request (#152)
+        rather than calling client.get() directly, so the fake response is
+        injected there."""
         from supacrawl.services.pdf import download_pdf
 
         # Create a mock response that exceeds the size limit
@@ -257,13 +248,7 @@ class TestPdfSizeLimit:
         mock_response.content = large_content
         mock_response.raise_for_status = MagicMock()
 
-        with patch("supacrawl.services.pdf.httpx.AsyncClient") as mock_client_cls:
-            mock_client = AsyncMock()
-            mock_client.get = AsyncMock(return_value=mock_response)
-            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-            mock_client.__aexit__ = AsyncMock(return_value=None)
-            mock_client_cls.return_value = mock_client
-
+        with patch("supacrawl.services.pdf.guarded_request", AsyncMock(return_value=mock_response)):
             with pytest.raises(ValueError, match="too large"):
                 await download_pdf("https://example.com/huge.pdf")
 
@@ -672,19 +657,18 @@ class TestScrapeServicePdfRouting:
         download_mock = AsyncMock()
 
         with (
-            patch("supacrawl.services.http_fetch.httpx.AsyncClient") as mock_client_cls,
+            patch("supacrawl.services.http_fetch.guarded_request", new_callable=AsyncMock) as mock_guarded_request,
             patch("supacrawl.services.pdf.parse_pdf", new_callable=AsyncMock, return_value=mock_result) as mock_parse,
             patch("supacrawl.services.pdf.download_pdf", download_mock),
         ):
-            # Simulate the httpx GET returning application/pdf content-type
+            # Simulate the guarded GET returning application/pdf content-type
+            # (fetch_static routes through url_guard.guarded_request, #152).
             mock_response = MagicMock()
             mock_response.headers = {"content-type": "application/pdf"}
             mock_response.status_code = 200
             mock_response.content = pdf_bytes
             mock_response.url = "https://arxiv.org/pdf/1706.03762"
-            mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client_cls.return_value)
-            mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
-            mock_client_cls.return_value.get = AsyncMock(return_value=mock_response)
+            mock_guarded_request.return_value = mock_response
 
             service = ScrapeService(headless=True)
             result = await service.scrape(
@@ -720,7 +704,7 @@ class TestScrapeServicePdfRouting:
         download_mock = AsyncMock()
 
         with (
-            patch("supacrawl.services.http_fetch.httpx.AsyncClient") as mock_client_cls,
+            patch("supacrawl.services.http_fetch.guarded_request", new_callable=AsyncMock) as mock_guarded_request,
             patch("supacrawl.services.pdf.parse_pdf", new_callable=AsyncMock, return_value=mock_result) as mock_parse,
             patch("supacrawl.services.pdf.download_pdf", download_mock),
         ):
@@ -729,9 +713,7 @@ class TestScrapeServicePdfRouting:
             mock_response.status_code = 200
             mock_response.content = pdf_bytes
             mock_response.url = "https://example.com/download/doc"
-            mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client_cls.return_value)
-            mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
-            mock_client_cls.return_value.get = AsyncMock(return_value=mock_response)
+            mock_guarded_request.return_value = mock_response
 
             service = ScrapeService(headless=True)
             result = await service.scrape(

--- a/tests/test_url_guard.py
+++ b/tests/test_url_guard.py
@@ -21,6 +21,7 @@ import os
 import socket
 from unittest.mock import MagicMock, patch
 
+import httpx
 import pytest
 
 from supacrawl.exceptions import ValidationError
@@ -351,6 +352,175 @@ class TestGuardedRequestRedirectChain:
         ):
             with pytest.raises(ValidationError, match="no Location header"):
                 await guarded_request(client, "GET", "https://example.com/report.pdf")
+
+    async def test_relative_location_resolves_against_the_logical_url(self) -> None:
+        """A relative Location keeps the real hostname, not the pinned-IP request URL.
+
+        Resolving against the pinned-IP URL would silently drop the vhost /
+        certificate identity, so the guard joins against the logical URL.
+        """
+        client, calls = self._client([(302, {"location": "/moved/here"}), (200, {})])
+        seen = []
+
+        def fake_resolve(url):
+            seen.append(url)
+            return ("93.184.216.34", "example.com")
+
+        with patch("supacrawl.services.url_guard.resolve_and_pin", side_effect=fake_resolve):
+            response = await guarded_request(client, "GET", "https://example.com/docs/a")
+
+        assert response.status_code == 200
+        assert seen == ["https://example.com/docs/a", "https://example.com/moved/here"]
+        assert calls[1]["url"] == "https://93.184.216.34/moved/here"
+
+    async def test_host_header_preserves_a_non_default_port(self) -> None:
+        """Host must carry a non-default port (RFC 7230 §5.4); SNI stays hostname-only."""
+        client, calls = self._client([(200, {})])
+
+        with patch(
+            "supacrawl.services.url_guard.resolve_and_pin",
+            return_value=("93.184.216.34", "example.com"),
+        ):
+            await guarded_request(client, "GET", "https://example.com:8443/x")
+
+        assert calls[0]["url"] == "https://93.184.216.34:8443/x"
+        assert calls[0]["headers"]["host"] == "example.com:8443"
+        assert calls[0]["extensions"]["sni_hostname"] == "example.com"
+
+
+class TestEmbeddedIPv4InIPv6:
+    """IPv4-mapped/6to4/NAT64 IPv6 forms are classified by their embedded IPv4 (#152).
+
+    The bypass this closes: an IPv6 literal is never ``in`` an IPv4 network, so
+    ``::ffff:169.254.169.254`` slipped past every IPv4 blocklist entry while
+    still routing to the metadata endpoint on a dual-stack host.
+    """
+
+    @pytest.mark.parametrize(
+        "literal",
+        [
+            "::ffff:169.254.169.254",  # IPv4-mapped metadata
+            "::ffff:a9fe:a9fe",  # same, hex-compressed
+            "2002:a9fe:a9fe::",  # 6to4 wrapping the metadata IPv4
+            "64:ff9b::a9fe:a9fe",  # NAT64 well-known prefix wrapping it
+        ],
+    )
+    def test_embedded_metadata_blocked_by_default(self, literal: str) -> None:
+        import ipaddress
+
+        assert is_blocked_address(ipaddress.ip_address(literal)) is True
+
+    def test_ipv4_mapped_metadata_url_refused_offline(self) -> None:
+        with pytest.raises(ValidationError, match="blocked"):
+            assert_safe_url("http://[::ffff:169.254.169.254]/latest/meta-data/")
+
+    def test_public_ipv4_mapped_still_allowed(self) -> None:
+        """A mapped/6to4 address embedding a PUBLIC IPv4 is legitimate, not blocked."""
+        assert_safe_url("http://[::ffff:8.8.8.8]/dns-query")
+
+    def test_ipv4_mapped_loopback_is_default_allow_strict_block(self) -> None:
+        import ipaddress
+
+        addr = ipaddress.ip_address("::ffff:127.0.0.1")
+        assert is_blocked_address(addr) is False
+        with patch.dict(os.environ, {"SUPACRAWL_BLOCK_PRIVATE_NETWORKS": "1"}):
+            assert is_blocked_address(addr) is True
+
+    def test_resolver_answering_with_mapped_metadata_is_refused(self) -> None:
+        """The rebinding form: an AAAA answer of IPv4-mapped metadata is refused at resolve."""
+        infos = [(socket.AF_INET6, socket.SOCK_STREAM, 6, "", ("::ffff:169.254.169.254", 443, 0, 0))]
+        with patch("supacrawl.services.url_guard.socket.getaddrinfo", return_value=infos):
+            with pytest.raises(ValidationError, match="blocked"):
+                resolve_and_pin("http://sneaky.example.com/")
+
+
+class TestStrictModeRanges:
+    """Every declared strict-mode range is actually enforced (guards against a typo'd CIDR)."""
+
+    @pytest.mark.parametrize(
+        "ip",
+        ["0.0.0.0", "0.1.2.3", "100.64.0.1", "127.0.0.1", "10.0.0.1", "172.16.0.1", "192.168.0.1"],
+    )
+    def test_ipv4_ranges_refused_in_strict(self, ip: str) -> None:
+        import ipaddress
+
+        with patch.dict(os.environ, {"SUPACRAWL_BLOCK_PRIVATE_NETWORKS": "1"}):
+            assert is_blocked_address(ipaddress.ip_address(ip)) is True
+
+    @pytest.mark.parametrize("ip", ["::1", "fc00::1", "fd12:3456::1"])
+    def test_ipv6_ranges_refused_in_strict(self, ip: str) -> None:
+        import ipaddress
+
+        with patch.dict(os.environ, {"SUPACRAWL_BLOCK_PRIVATE_NETWORKS": "1"}):
+            assert is_blocked_address(ipaddress.ip_address(ip)) is True
+
+    @pytest.mark.parametrize("ip", ["0.0.0.0", "100.64.0.1", "::1", "fc00::1"])
+    def test_ranges_allowed_by_default(self, ip: str) -> None:
+        import ipaddress
+
+        assert is_blocked_address(ipaddress.ip_address(ip)) is False
+
+
+class TestGuardedRequestRealSocket:
+    """End-to-end proof against a loopback listener: the CONNECT lands on the pinned address.
+
+    The mocked-client tests prove request construction; these drive a real
+    ``httpx.AsyncClient`` so the socket layer — where the IPv4-mapped bypass
+    slipped through untested — is actually exercised (#152's 'local listener').
+    """
+
+    @staticmethod
+    def _listener():
+        import http.server
+        import threading
+
+        received: list[str] = []
+
+        class Handler(http.server.BaseHTTPRequestHandler):
+            def do_GET(self) -> None:  # noqa: N802 (BaseHTTPRequestHandler API)
+                received.append(self.headers.get("Host", ""))
+                body = b"OK-REAL-LISTENER"
+                self.send_response(200)
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+            def log_message(self, *args: object) -> None:
+                pass
+
+        server = http.server.HTTPServer(("127.0.0.1", 0), Handler)
+        port = server.server_address[1]
+        threading.Thread(target=server.serve_forever, daemon=True).start()
+        return server, port, received
+
+    async def test_connects_to_pinned_loopback_with_real_host(self) -> None:
+        server, port, received = self._listener()
+        try:
+            infos = [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("127.0.0.1", port))]
+            with patch("supacrawl.services.url_guard.socket.getaddrinfo", return_value=infos):
+                async with httpx.AsyncClient(timeout=5.0) as client:
+                    resp = await guarded_request(client, "GET", f"http://docs.internal.test:{port}/x")
+
+            assert resp.status_code == 200
+            assert resp.text == "OK-REAL-LISTENER"
+            # The real connect used the pinned 127.0.0.1, and the Host header
+            # carried the true hostname AND port (not the pinned IP).
+            assert received == [f"docs.internal.test:{port}"]
+        finally:
+            server.shutdown()
+
+    async def test_ipv4_mapped_loopback_refused_before_any_socket_in_strict_mode(self) -> None:
+        """The reviewer's confirmed bypass: ::ffff:127.0.0.1 must never reach the listener."""
+        server, port, received = self._listener()
+        try:
+            with patch.dict(os.environ, {"SUPACRAWL_BLOCK_PRIVATE_NETWORKS": "1"}):
+                async with httpx.AsyncClient(timeout=5.0) as client:
+                    with pytest.raises(ValidationError, match="blocked"):
+                        await guarded_request(client, "GET", f"http://[::ffff:127.0.0.1]:{port}/x")
+
+            assert received == []
+        finally:
+            server.shutdown()
 
 
 async def _async_noop(*args, **kwargs) -> None:

--- a/tests/test_url_guard.py
+++ b/tests/test_url_guard.py
@@ -1,0 +1,357 @@
+"""Tests for the outbound URL safety guard (SSRF hardening, #152).
+
+Covers:
+- Non-http(s) schemes are rejected.
+- Cloud-metadata / link-local IP literals are rejected (169.254.x.x, fe80::).
+- Normal public URLs are allowed.
+- RFC1918 private ranges are allowed by default, refused under the strict switch.
+- A hostname resolving to a blocked address is refused at connect time, not
+  just when the URL contains an IP literal (the rebinding window #152 exists
+  to close).
+- guarded_request/guarded_stream pin every redirect hop, refusing a 3xx pivot
+  to an internal address exactly like a direct request to it.
+
+Uses a stubbed resolver (patching socket.getaddrinfo) and a fake httpx client
+so no real network egress or DNS is needed, per #152's test requirements.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from supacrawl.exceptions import ValidationError
+from supacrawl.services.url_guard import (
+    _is_blocked_ip,
+    assert_safe_url,
+    guarded_request,
+    is_blocked_address,
+    pinned_url,
+    resolve_and_pin,
+)
+
+
+class TestAssertSafeUrl:
+    """assert_safe_url raises ValidationError for unsafe URLs, passes safe ones."""
+
+    def test_http_allowed(self) -> None:
+        assert_safe_url("http://docs.example.com/guide")
+
+    def test_https_allowed(self) -> None:
+        assert_safe_url("https://docs.example.com/guide")
+
+    def test_file_scheme_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="file"):
+            assert_safe_url("file:///etc/passwd")
+
+    def test_ftp_scheme_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="ftp"):
+            assert_safe_url("ftp://files.example.com/data.csv")
+
+    def test_data_scheme_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="data"):
+            assert_safe_url("data:text/html,<h1>Hi</h1>")
+
+    def test_javascript_scheme_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="javascript"):
+            assert_safe_url("javascript:alert(1)")
+
+    def test_aws_metadata_ip_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="blocked"):
+            assert_safe_url("http://169.254.169.254/latest/meta-data/")
+
+    def test_link_local_other_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="blocked"):
+            assert_safe_url("http://169.254.0.1/resource")
+
+    def test_ipv6_link_local_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="blocked"):
+            assert_safe_url("http://[fe80::1]/resource")
+
+    def test_public_ip_allowed(self) -> None:
+        assert_safe_url("https://8.8.8.8/dns-query")
+
+    def test_rfc1918_192168_allowed_by_default(self) -> None:
+        assert_safe_url("http://192.168.1.10/docs/")
+
+    def test_rfc1918_10_allowed_by_default(self) -> None:
+        assert_safe_url("http://10.0.1.2:8080/api/")
+
+    def test_rfc1918_172_allowed_by_default(self) -> None:
+        assert_safe_url("http://172.16.0.5/internal/")
+
+    def test_loopback_allowed_by_default(self) -> None:
+        assert_safe_url("http://127.0.0.1:8080/")
+
+    def test_hostname_allowed(self) -> None:
+        """Plain hostnames are not resolved by this check; caught later by resolve_and_pin."""
+        assert_safe_url("https://internal.corp/docs/")
+
+    def test_rfc1918_ip_literal_rejected_in_strict_mode(self) -> None:
+        with patch.dict(os.environ, {"SUPACRAWL_BLOCK_PRIVATE_NETWORKS": "1"}):
+            with pytest.raises(ValidationError, match="blocked"):
+                assert_safe_url("http://192.168.1.10/docs/")
+
+    def test_metadata_still_rejected_in_strict_mode(self) -> None:
+        with patch.dict(os.environ, {"SUPACRAWL_BLOCK_PRIVATE_NETWORKS": "1"}):
+            with pytest.raises(ValidationError, match="blocked"):
+                assert_safe_url("http://169.254.169.254/latest/meta-data/")
+
+
+class TestIsBlockedIp:
+    """_is_blocked_ip correctly classifies IP literals; non-IP hosts pass through."""
+
+    def test_metadata_ip_blocked(self) -> None:
+        assert _is_blocked_ip("169.254.169.254") is True
+
+    def test_link_local_subnet_blocked(self) -> None:
+        assert _is_blocked_ip("169.254.1.1") is True
+
+    def test_public_ip_not_blocked(self) -> None:
+        assert _is_blocked_ip("1.1.1.1") is False
+
+    def test_rfc1918_not_blocked_by_default(self) -> None:
+        assert _is_blocked_ip("10.0.0.1") is False
+
+    def test_hostname_not_blocked(self) -> None:
+        assert _is_blocked_ip("docs.example.com") is False
+
+    def test_ipv6_link_local_blocked(self) -> None:
+        assert _is_blocked_ip("fe80::1") is True
+
+    def test_ipv6_public_not_blocked(self) -> None:
+        assert _is_blocked_ip("2001:db8::1") is False
+
+
+class TestIsBlockedAddress:
+    """is_blocked_address checks a parsed address against the current policy."""
+
+    def test_metadata_address_blocked(self) -> None:
+        import ipaddress
+
+        assert is_blocked_address(ipaddress.ip_address("169.254.169.254")) is True
+
+    def test_rfc1918_address_not_blocked_by_default(self) -> None:
+        import ipaddress
+
+        assert is_blocked_address(ipaddress.ip_address("192.168.1.1")) is False
+
+    def test_rfc1918_address_blocked_in_strict_mode(self) -> None:
+        import ipaddress
+
+        with patch.dict(os.environ, {"SUPACRAWL_BLOCK_PRIVATE_NETWORKS": "true"}):
+            assert is_blocked_address(ipaddress.ip_address("192.168.1.1")) is True
+
+
+class TestResolveAndPin:
+    """resolve_and_pin closes the DNS-rebinding window (#152)."""
+
+    @staticmethod
+    def _stub_resolver(*addresses: str):
+        """Patch getaddrinfo to answer with the given addresses."""
+        infos = [(socket.AF_INET, socket.SOCK_STREAM, 6, "", (a, 443)) for a in addresses]
+        return patch("supacrawl.services.url_guard.socket.getaddrinfo", return_value=infos)
+
+    def test_public_host_returns_its_pinned_address(self) -> None:
+        with self._stub_resolver("93.184.216.34"):
+            address, host = resolve_and_pin("https://docs.example.com/guide")
+
+        assert address == "93.184.216.34"
+        assert host == "docs.example.com"
+
+    def test_hostname_resolving_to_metadata_is_refused(self) -> None:
+        """The attack the IP-literal check cannot see: a name pointing at IMDS."""
+        with self._stub_resolver("169.254.169.254"):
+            with pytest.raises(ValidationError, match="169.254.169.254"):
+                resolve_and_pin("http://totally-innocent.example.com/latest/meta-data/")
+
+    def test_hostname_resolving_to_ipv6_link_local_is_refused(self) -> None:
+        infos = [(socket.AF_INET6, socket.SOCK_STREAM, 6, "", ("fe80::1", 443, 0, 0))]
+        with patch("supacrawl.services.url_guard.socket.getaddrinfo", return_value=infos):
+            with pytest.raises(ValidationError, match="link-local"):
+                resolve_and_pin("http://evil.example.com/")
+
+    def test_any_blocked_address_refuses_the_whole_fetch(self) -> None:
+        """A name answering with both a public and an internal address is refused.
+
+        Picking the address that passes would be exactly the rebinding attack:
+        the resolver is free to hand the connection the other one.
+        """
+        with self._stub_resolver("93.184.216.34", "169.254.169.254"):
+            with pytest.raises(ValidationError, match="169.254.169.254"):
+                resolve_and_pin("https://rebind.example.com/")
+
+    def test_unresolvable_host_is_refused(self) -> None:
+        with patch(
+            "supacrawl.services.url_guard.socket.getaddrinfo",
+            side_effect=socket.gaierror("nodename nor servname"),
+        ):
+            with pytest.raises(ValidationError, match="Cannot resolve"):
+                resolve_and_pin("https://nx.example.com/")
+
+    def test_private_address_allowed_by_default(self) -> None:
+        """Internal documentation sites stay crawlable: RFC1918 is not blocked by default."""
+        with self._stub_resolver("192.168.1.10"):
+            address, _host = resolve_and_pin("http://docs.internal.corp/")
+
+        assert address == "192.168.1.10"
+
+    def test_private_address_refused_in_strict_mode(self) -> None:
+        with self._stub_resolver("192.168.1.10"), patch.dict(os.environ, {"SUPACRAWL_BLOCK_PRIVATE_NETWORKS": "1"}):
+            with pytest.raises(ValidationError, match="private / loopback"):
+                resolve_and_pin("http://docs.internal.corp/")
+
+    def test_loopback_refused_in_strict_mode(self) -> None:
+        with self._stub_resolver("127.0.0.1"), patch.dict(os.environ, {"SUPACRAWL_BLOCK_PRIVATE_NETWORKS": "1"}):
+            with pytest.raises(ValidationError, match="private / loopback"):
+                resolve_and_pin("http://localhost:8080/")
+
+    def test_metadata_still_refused_in_strict_mode(self) -> None:
+        """Strict mode adds ranges; it never drops the always-blocked ones."""
+        with self._stub_resolver("169.254.169.254"), patch.dict(os.environ, {"SUPACRAWL_BLOCK_PRIVATE_NETWORKS": "1"}):
+            with pytest.raises(ValidationError, match="link-local"):
+                resolve_and_pin("http://evil.example.com/")
+
+    def test_bad_scheme_refused_before_any_resolution(self) -> None:
+        with patch("supacrawl.services.url_guard.socket.getaddrinfo") as mock_resolve:
+            with pytest.raises(ValidationError, match="scheme"):
+                resolve_and_pin("file:///etc/passwd")
+
+        mock_resolve.assert_not_called()
+
+    def test_no_usable_address_is_refused(self) -> None:
+        """getaddrinfo answering with no parseable address is refused, not silently passed."""
+        infos = [(socket.AF_UNIX, socket.SOCK_STREAM, 0, "", "/tmp/weird.sock")]
+        with patch("supacrawl.services.url_guard.socket.getaddrinfo", return_value=infos):
+            with pytest.raises(ValidationError, match="no usable address"):
+                resolve_and_pin("https://odd.example.com/")
+
+
+class TestPinnedUrl:
+    """pinned_url rewrites the authority without disturbing the rest."""
+
+    def test_replaces_host_keeping_path_and_query(self) -> None:
+        assert pinned_url("https://example.com/a/b?x=1", "93.184.216.34") == "https://93.184.216.34/a/b?x=1"
+
+    def test_preserves_explicit_port(self) -> None:
+        assert pinned_url("http://example.com:8080/docs", "10.0.0.5") == "http://10.0.0.5:8080/docs"
+
+    def test_brackets_ipv6_literal(self) -> None:
+        assert pinned_url("https://example.com/x", "2606:2800:220:1::1") == "https://[2606:2800:220:1::1]/x"
+
+
+class TestGuardedRequestRedirectChain:
+    """guarded_request/guarded_stream guard and pin every redirect hop (#152)."""
+
+    @staticmethod
+    def _client(responses):
+        """Build a fake httpx.AsyncClient whose .send() replays *responses* in order.
+
+        Each entry is (status_code, headers dict).
+        """
+        calls: list[dict[str, object]] = []
+
+        async def mock_send(request, *, stream, follow_redirects):
+            status, headers = responses[len(calls)]
+            calls.append(
+                {
+                    "url": str(request.url),
+                    "headers": dict(request.headers),
+                    "extensions": request.extensions,
+                }
+            )
+            resp = MagicMock()
+            resp.is_redirect = 300 <= status < 400
+            resp.headers = headers
+            resp.status_code = status
+            resp.aclose = _async_noop
+            resp.aread = _async_noop
+            return resp
+
+        class FakeClient:
+            """Fake httpx.AsyncClient exposing only build_request/send."""
+
+            def build_request(self, method, url, *, headers=None, extensions=None):
+                import httpx
+
+                return httpx.Request(method, url, headers=headers, extensions=extensions)
+
+            send = staticmethod(mock_send)
+
+        return FakeClient(), calls
+
+    async def test_connects_to_the_pinned_address_with_the_real_host(self) -> None:
+        client, calls = self._client([(200, {})])
+
+        with patch(
+            "supacrawl.services.url_guard.resolve_and_pin",
+            return_value=("93.184.216.34", "example.com"),
+        ):
+            response = await guarded_request(client, "GET", "https://example.com/report.pdf")
+
+        assert response.status_code == 200
+        assert calls[0]["url"] == "https://93.184.216.34/report.pdf"
+        assert calls[0]["headers"]["host"] == "example.com"
+        assert calls[0]["extensions"]["sni_hostname"] == "example.com"
+
+    async def test_redirect_to_an_internal_address_is_refused(self) -> None:
+        """A 30x pivot to the metadata endpoint is refused like a direct request."""
+        client, _calls = self._client([(302, {"location": "http://169.254.169.254/latest/meta-data/"})])
+
+        def fake_resolve(url):
+            if "169.254.169.254" in url:
+                raise ValidationError("blocked range (link-local / cloud-metadata)", field="url", value=url)
+            return ("93.184.216.34", "example.com")
+
+        with patch("supacrawl.services.url_guard.resolve_and_pin", side_effect=fake_resolve):
+            with pytest.raises(ValidationError, match="link-local"):
+                await guarded_request(client, "GET", "https://example.com/report.pdf")
+
+    async def test_each_hop_is_revalidated(self) -> None:
+        """Every hop is resolved and validated, not just the first."""
+        client, calls = self._client(
+            [
+                (302, {"location": "https://cdn.example.com/real.pdf"}),
+                (200, {}),
+            ]
+        )
+        seen = []
+
+        def fake_resolve(url):
+            seen.append(url)
+            return ("93.184.216.34", "cdn.example.com" if "cdn" in url else "example.com")
+
+        with patch("supacrawl.services.url_guard.resolve_and_pin", side_effect=fake_resolve):
+            response = await guarded_request(client, "GET", "https://example.com/report.pdf")
+
+        assert response.status_code == 200
+        assert seen == ["https://example.com/report.pdf", "https://cdn.example.com/real.pdf"]
+        assert len(calls) == 2
+
+    async def test_too_many_redirects_is_refused(self) -> None:
+        """A redirect chain deeper than max_redirects is refused, not followed forever."""
+        client, _calls = self._client([(302, {"location": "https://example.com/next"})] * 3)
+
+        with patch(
+            "supacrawl.services.url_guard.resolve_and_pin",
+            return_value=("93.184.216.34", "example.com"),
+        ):
+            with pytest.raises(ValidationError, match="Too many redirects"):
+                await guarded_request(client, "GET", "https://example.com/start", max_redirects=2)
+
+    async def test_redirect_with_no_location_header_is_refused(self) -> None:
+        client, _calls = self._client([(302, {})])
+
+        with patch(
+            "supacrawl.services.url_guard.resolve_and_pin",
+            return_value=("93.184.216.34", "example.com"),
+        ):
+            with pytest.raises(ValidationError, match="no Location header"):
+                await guarded_request(client, "GET", "https://example.com/report.pdf")
+
+
+async def _async_noop(*args, **kwargs) -> None:
+    return None

--- a/tests/test_url_guard.py
+++ b/tests/test_url_guard.py
@@ -26,6 +26,7 @@ import pytest
 
 from supacrawl.exceptions import ValidationError
 from supacrawl.services.url_guard import (
+    _authority,
     _is_blocked_ip,
     assert_safe_url,
     guarded_request,
@@ -244,6 +245,22 @@ class TestPinnedUrl:
         assert pinned_url("https://example.com/x", "2606:2800:220:1::1") == "https://[2606:2800:220:1::1]/x"
 
 
+class TestAuthority:
+    """_authority builds the Host header: hostname, port preserved, IPv6 bracketed."""
+
+    def test_plain_hostname_no_port(self) -> None:
+        assert _authority("example.com", None) == "example.com"
+
+    def test_hostname_with_explicit_port(self) -> None:
+        assert _authority("example.com", 8443) == "example.com:8443"
+
+    def test_ipv6_hostname_is_bracketed(self) -> None:
+        assert _authority("2606:2800:220:1::1", None) == "[2606:2800:220:1::1]"
+
+    def test_ipv6_hostname_with_port_is_bracketed(self) -> None:
+        assert _authority("2606:2800:220:1::1", 8443) == "[2606:2800:220:1::1]:8443"
+
+
 class TestGuardedRequestRedirectChain:
     """guarded_request/guarded_stream guard and pin every redirect hop (#152)."""
 
@@ -403,6 +420,7 @@ class TestEmbeddedIPv4InIPv6:
             "::ffff:a9fe:a9fe",  # same, hex-compressed
             "2002:a9fe:a9fe::",  # 6to4 wrapping the metadata IPv4
             "64:ff9b::a9fe:a9fe",  # NAT64 well-known prefix wrapping it
+            "::169.254.169.254",  # deprecated IPv4-compatible form
         ],
     )
     def test_embedded_metadata_blocked_by_default(self, literal: str) -> None:
@@ -413,6 +431,18 @@ class TestEmbeddedIPv4InIPv6:
     def test_ipv4_mapped_metadata_url_refused_offline(self) -> None:
         with pytest.raises(ValidationError, match="blocked"):
             assert_safe_url("http://[::ffff:169.254.169.254]/latest/meta-data/")
+
+    def test_ipv4_compat_metadata_url_refused_offline(self) -> None:
+        with pytest.raises(ValidationError, match="blocked"):
+            assert_safe_url("http://[::169.254.169.254]/latest/meta-data/")
+
+    def test_ipv6_loopback_not_misread_as_ipv4_compat(self) -> None:
+        """``::1`` stays IPv6 loopback (strict-only), not IPv4-compatible 0.0.0.1."""
+        import ipaddress
+
+        assert is_blocked_address(ipaddress.ip_address("::1")) is False
+        with patch.dict(os.environ, {"SUPACRAWL_BLOCK_PRIVATE_NETWORKS": "1"}):
+            assert is_blocked_address(ipaddress.ip_address("::1")) is True
 
     def test_public_ipv4_mapped_still_allowed(self) -> None:
         """A mapped/6to4 address embedding a PUBLIC IPv4 is legitimate, not blocked."""

--- a/tests/test_url_guard.py
+++ b/tests/test_url_guard.py
@@ -103,6 +103,40 @@ class TestAssertSafeUrl:
                 assert_safe_url("http://169.254.169.254/latest/meta-data/")
 
 
+class TestParserDivergenceReject:
+    """Backslash / control-char URLs are refused before parse (RFC 3986 vs WHATWG, #152).
+
+    Python's urlparse and a WHATWG browser engine disagree on the authority of
+    such a URL, so the browser pre-flight would validate a different host than
+    Chromium navigates to. Rejecting the raw character at the shared chokepoint
+    closes it for both the httpx and browser paths.
+    """
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "http://169.254.169.254\\@allowed-host.example/steal",  # backslash userinfo trick
+            "https://allowed.example\\@169.254.169.254/",
+            "http://169.254.169.254\t@allowed.example/",  # tab
+            "http://169.254.169.254\n@allowed.example/",  # newline
+            "http://allowed.example\r/path",  # carriage return
+        ],
+    )
+    def test_parser_divergence_urls_refused(self, url: str) -> None:
+        with pytest.raises(ValidationError, match="percent-encode|control character|interpret"):
+            assert_safe_url(url)
+
+    def test_resolve_and_pin_refuses_backslash_before_resolving(self) -> None:
+        with patch("supacrawl.services.url_guard.socket.getaddrinfo") as mock_resolve:
+            with pytest.raises(ValidationError):
+                resolve_and_pin("http://127.0.0.1\\@example.com/")
+        mock_resolve.assert_not_called()
+
+    def test_percent_encoded_backslash_is_allowed(self) -> None:
+        """A properly percent-encoded backslash (%5C) is legitimate and passes."""
+        assert_safe_url("https://docs.example.com/path%5Cwith-encoded-backslash")
+
+
 class TestIsBlockedIp:
     """_is_blocked_ip correctly classifies IP literals; non-IP hosts pass through."""
 


### PR DESCRIPTION
Closes #152 once merged. **⚠️ SECURITY BOUNDARY — do not merge without a human security review.**

## What this does
Adds an outbound URL SSRF guard so every supacrawl fetch (scrape/crawl/map/pdf/robots/sitemap/search-result probe) connects only to an address validated as non-internal, with no DNS-rebinding window, and re-validates every redirect hop. Link-local/cloud-metadata (169.254.0.0/16, fe80::/10) is always blocked; RFC1918/loopback stays reachable by default (internal docs sites are first-class) and is refused under `SUPACRAWL_BLOCK_PRIVATE_NETWORKS`. Mirrors ragify's switch shape.

## Review trail
`cf956bb` is the original guard. It then went through a fresh-context, multi-lens adversarial review (bypass-encoding / correctness / completeness / test-adequacy) with each finding independently verified. That surfaced a **critical bypass** and hardening gaps, all fixed here:

- **`9e8ef9b`** — CRITICAL: an IPv4-mapped IPv6 literal (`::ffff:169.254.169.254`), plus 6to4/NAT64 forms, slipped past the classifier because an IPv6 address is never `in` an IPv4 network — yet it routes to the IPv4 metadata endpoint on a dual-stack host. Verified end-to-end against a real loopback listener. Also: guarded the benchmark reference renderer's `page.goto`; preserved a non-default port in the `Host` header (RFC 7230 §5.4); moved the blocking `getaddrinfo` off the event loop.
- **`6007681`** — a follow-up delta re-review (verdict: ship) noted the deprecated IPv4-compatible `::a.b.c.d` embedding was still uncovered; closed it, so every destination-embedding IPv6 form is now checked. Teredo (`2001::/32`) is documented as an accepted residual (embeds the server, not the destination; no supported OS auto-tunnels it).

## Honestly-documented residuals
- **Browser engines** (Playwright/patchright/camoufox) own their network stack — they get a `resolve_and_pin` pre-flight but the engine re-resolves at connect, so that hop is not pinned. Documented in `url_guard.py`'s module docstring.
- Teredo (above).

## Gates
1274 non-e2e tests pass (incl. a real loopback-listener integration test proving the connect lands on the pinned address); ruff, mypy, and all pre-commit hooks green. Test coverage added for: the IPv4-mapped/6to4/NAT64/compat class, connect-time refusal via a stubbed resolver, redirect-to-internal (incl. relative Location), Host-with-port, strict-mode ranges, MCP `validate_url`, and the browser pre-flight.

The last two commits (`8563de5` + merge) are an unrelated fix that unbroke main's CI (a #156 test file crashed collection and had 6 mypy errors); merged in so this branch's CI is green.

## Reviewer asks
- Sanity-check the embedded-IPv4 normalisation in `_candidate_addresses` and the `sni_hostname` cert-verification approach in `guarded_stream`.
- Confirm the accepted residuals (browser pinning gap, Teredo) are acceptable for your threat model.