### PR TITLE
fix(engine): resilient stealth-engine startup, honest diagnostics, launch smoke-test (#143 #154 #144 #145 #146)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -169,8 +169,12 @@ jobs:
       #               those specific @pytest.mark.mcp classes still need
       #               excluding at run time.
       # All of the above run locally (`uv sync --all-groups` installs mcp-dev).
+      #   -m "not stealth_smoke" — the #145 engine-launch smoke tests need every
+      #               engine's browser binary fetched (camoufox fetch especially),
+      #               which this job does not do; they run in the dedicated
+      #               stealth-smoke job below.
       - name: Test
-        run: uv run pytest -m "not e2e and not mcp" --ignore=tests/test_mcp --ignore=tests/test_health_search_config.py --ignore=tests/test_health_search_probe.py --ignore=tests/test_provider_fallback_visibility.py
+        run: uv run pytest -m "not e2e and not mcp and not stealth_smoke" --ignore=tests/test_mcp --ignore=tests/test_health_search_config.py --ignore=tests/test_health_search_probe.py --ignore=tests/test_provider_fallback_visibility.py
 
       # ntfy-failure inlined (public repo, see lint/typecheck jobs above); this
       # job runs on ubuntu-latest so the atlas host token files below don't
@@ -181,6 +185,75 @@ jobs:
         shell: bash
         env:
           NTFY_TITLE: 'supacrawl: test failed'
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          NTFY_TOKEN: ${{ secrets.NTFY_TOKEN }}
+        run: |
+          TOKEN="$NTFY_TOKEN"
+          for f in /etc/ntfy/tokens/ci-publisher.token /run/secrets/ntfy/systemd; do
+            [ -n "$TOKEN" ] && break
+            [ -r "$f" ] && TOKEN="$(cat "$f")"
+          done
+          if [ -z "$TOKEN" ]; then
+            echo "::warning::ntfy-failure: no token available — failure notification NOT sent"
+            exit 0
+          fi
+          curl -sS --max-time 10 \
+            -H "Authorization: Bearer $TOKEN" \
+            -H "Title: $NTFY_TITLE" \
+            -H "Priority: 4" \
+            -H "Tags: rotating_light" \
+            -d "Run: $RUN_URL" \
+            "https://ntfy.godswood.au/infra" \
+            || echo "::warning::ntfy-failure: notification POST failed"
+
+  stealth-smoke:
+    name: stealth-smoke
+    # #145: actually launch each stealth engine headless, so a broken stealth
+    # extra (install, version skew, missing binary) fails supacrawl's own
+    # pipeline instead of a downstream container build or a consumer at runtime.
+    # Separate from `test` because it fetches every engine's browser binary —
+    # `camoufox fetch` especially, which the main job does not run. ubuntu-latest
+    # for the same reason as `test`: Playwright's `--with-deps` needs apt+sudo the
+    # NixOS atlas runner does not have (supacrawl#147).
+    runs-on: ubuntu-latest
+    env:
+      UV_FROZEN: '1'
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up uv (and Python 3.14)
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          python-version: '3.14'
+          enable-cache: true
+
+      # The dev group pulls in the stealth + camoufox extras (patchright,
+      # camoufox); --no-group mcp-dev keeps the unresolvable MCP slice out.
+      - name: Install dependencies
+        run: uv sync --no-group mcp-dev
+
+      # Every engine's browser binary must be present for a real launch:
+      #   playwright/patchright share the ms-playwright Chromium registry;
+      #   camoufox fetches its own patched Firefox build.
+      - name: Install engine browsers (Chromium + Camoufox)
+        run: |
+          uv run playwright install --with-deps chromium
+          uv run patchright install --with-deps chromium
+          uv run camoufox fetch
+
+      # Target the smoke file directly: this job installs without the mcp group,
+      # so collecting the whole suite would fail at import on the MCP test modules
+      # (fastmcp absent) before the marker filter runs — the same reason the main
+      # test job carries its own --ignore list. The marker still gates the file's
+      # contents and keeps it out of the main job.
+      - name: Smoke-test each stealth engine launches headless
+        run: uv run pytest tests/test_engine_smoke.py -m stealth_smoke -p no:cacheprovider
+
+      - name: Notify failure (ntfy infra)
+        if: failure() && github.event_name != 'pull_request'
+        shell: bash
+        env:
+          NTFY_TITLE: 'supacrawl: stealth-smoke failed'
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           NTFY_TOKEN: ${{ secrets.NTFY_TOKEN }}
         run: |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -43,6 +43,7 @@ Every setting is a standing default; a per-request flag or API argument still ov
 | browser | `headless` | `SUPACRAWL_HEADLESS` | `true` | Run without a visible window. |
 | browser | `wait_until` | `SUPACRAWL_WAIT_UNTIL` | `domcontentloaded` | `domcontentloaded` / `load` / `networkidle`. |
 | browser | `user_agent` | `SUPACRAWL_USER_AGENT` | _(engine default)_ | Override the User-Agent string. |
+| browser | _(env only)_ | `SUPACRAWL_DISABLE_DEV_SHM` | _(auto: on in a container)_ | Pass `--disable-dev-shm-usage` to Chromium so it uses disk instead of the container's small `/dev/shm`, avoiding crashes on heavy pages. Auto-detected inside a container; set `1`/`0` to force on/off. Chromium engines only (playwright/patchright); Camoufox is Firefox. |
 | locale | `locale` | `SUPACRAWL_LOCALE` | `en-US` | Maps to Accept-Language. |
 | locale | `timezone` | `SUPACRAWL_TIMEZONE` | `UTC` | e.g. `Australia/Brisbane`. |
 | anti_bot | `engine` | `SUPACRAWL_ENGINE` | _(auto)_ | `playwright` / `patchright` / `camoufox`. Leave unset to auto-escalate. |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,6 +124,7 @@ markers = [
     "integration: Filesystem-heavy tests, may use local HTTP server and Playwright",
     "e2e: End-to-end tests with live network and Playwright",
     "mcp: MCP server tests (requires supacrawl[mcp])",
+    "stealth_smoke: Launches each stealth engine headless (#145); dedicated CI job only",
 ]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"

--- a/src/supacrawl/mcp/tools/diagnose.py
+++ b/src/supacrawl/mcp/tools/diagnose.py
@@ -42,6 +42,10 @@ async def supacrawl_diagnose(
         - content_length: Content-Length or actual length
         - indicators: Detection results (CDN, JS framework, bot protection)
         - recommendations: Suggested scrape settings and explanations
+        - engines: Per-engine availability (playwright/patchright/camoufox),
+          each {installed, available, reason}, computed without launching a
+          browser — so you can see which stealth tiers are usable and why one
+          is not
 
     Example:
         # Pre-check before scraping

--- a/src/supacrawl/mcp/tools/health.py
+++ b/src/supacrawl/mcp/tools/health.py
@@ -283,6 +283,13 @@ def _get_browser_config(browser_manager: Any | None = None) -> dict[str, Any]:
     }
     if browser_manager is not None:
         config["engine"] = browser_manager.engine
+        # Lazy start (#143): a server-side engine does not launch until the first
+        # tool needs it, so a never-launched manager is legitimately not alive —
+        # not a #160 outage. `launched` separates "not started yet" (fine) from
+        # "started then died" (the real outage the verdict must catch). Stubs and
+        # older managers without the property default to launched=True, preserving
+        # the dead-engine signal.
+        config["launched"] = getattr(browser_manager, "has_launched", True)
         config["alive"] = browser_manager.is_alive
         # Relaunches are cumulative for the process: a climbing count is a real
         # signal that something keeps killing the engine.
@@ -324,9 +331,11 @@ async def supacrawl_health(api_client: SupacrawlServices, verify_search: bool = 
           "live_probe" key is present only when the probe actually ran (verify_search=True
           and a search service is available), reporting what it found.
         - components.browser: engine, headless, stealth, timeout settings, plus
-          live `alive` / `relaunches` for the shared engine. `alive: false` means
-          the engine crashed; it self-heals on the next scrape, and drives the
-          top-level status to "degraded" with a warning until it does.
+          live `launched` / `alive` / `relaunches` for the shared engine. The
+          engine starts lazily on the first scrape, so `launched: false` with
+          `alive: false` means "not started yet" and is NOT degraded. Once
+          launched, `alive: false` means the engine crashed; it self-heals on the
+          next scrape and drives the top-level status to "degraded" until it does.
         - components.llm: configured provider and model (for json/summary formats)
         - components.cache: path, entry count, size
         - version: supacrawl library and MCP server versions
@@ -338,7 +347,9 @@ async def supacrawl_health(api_client: SupacrawlServices, verify_search: bool = 
         browser_config = _get_browser_config(api_client.browser_manager)
         # A dead shared engine is a real outage for every consumer of this server,
         # so it must reach the top-line verdict rather than sit one level down.
-        if browser_config.get("alive") is False:
+        # But only once it has actually launched: with lazy start (#143) a fresh
+        # engine is not-yet-launched, not crashed, and must not read as degraded.
+        if browser_config.get("alive") is False and browser_config.get("launched", True):
             all_healthy = False
             browser_config["warning"] = (
                 "The shared browser engine is not connected. It is relaunched automatically on the next "

--- a/src/supacrawl/services/browser.py
+++ b/src/supacrawl/services/browser.py
@@ -38,12 +38,15 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
+import importlib.util
 import json
 import logging
 import os
 import re
+import sys
 import time
 from dataclasses import dataclass
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, cast
 from urllib.parse import urlparse
 
@@ -353,6 +356,183 @@ def is_closed_browser_error(error: BaseException) -> bool:
 # Valid engine choices
 ENGINE_CHOICES = ("playwright", "patchright", "camoufox")
 
+
+# --- Per-engine availability, without launching a browser (#144) ---------------
+# Report which engines are usable so an operator or agent can see which stealth
+# tiers are available and understand why a tool failed — cheaply and safely,
+# with no browser process started. The companion CI smoke-test (#145) actually
+# launches each engine, so an "available" verdict here is independently proven
+# launchable: this check must never be a confident liar (the supacrawl#158 class,
+# where a component reported ready while it was not).
+
+# Reason categories reported when an engine is unusable. Deliberately coarse and
+# machine-readable — they say WHAT is missing, and never leak an internal path.
+ENGINE_REASON_NOT_INSTALLED = "not_installed"  # the Python package is absent
+ENGINE_REASON_BROWSER_NOT_INSTALLED = "browser_not_installed"  # package present, browser binary not fetched
+
+# The Python package that backs each engine.
+_ENGINE_PACKAGE = {
+    "playwright": "playwright",
+    "patchright": "patchright",
+    "camoufox": "camoufox",
+}
+
+# An actionable install hint per engine, surfaced when it is unavailable.
+_ENGINE_INSTALL_HINT = {
+    "playwright": "playwright is a base dependency; run: playwright install chromium",
+    "patchright": "pip install supacrawl[stealth]; then: patchright install chromium",
+    "camoufox": "pip install supacrawl[camoufox]; then: camoufox fetch",
+}
+
+
+def _package_installed(package: str) -> bool:
+    """Whether an engine's Python package is importable, without importing it."""
+    try:
+        return importlib.util.find_spec(package) is not None
+    except ImportError, ValueError:
+        return False
+
+
+def _playwright_browsers_dir() -> Path | None:
+    """Resolve Playwright's browser-download directory without starting the driver.
+
+    Mirrors Playwright's own default: ``PLAYWRIGHT_BROWSERS_PATH`` when set (the
+    literal ``"0"`` means "bundled next to the package", which cannot be resolved
+    cheaply, so we report it as unknown), otherwise the per-OS cache directory.
+    Both playwright and patchright fetch Chromium into this same registry.
+    """
+    env = os.getenv("PLAYWRIGHT_BROWSERS_PATH")
+    if env:
+        if env == "0":
+            return None  # bundled next to the package; not resolvable cheaply
+        return Path(env)
+    if sys.platform == "darwin":
+        return Path.home() / "Library" / "Caches" / "ms-playwright"
+    if sys.platform == "win32":
+        local = os.getenv("LOCALAPPDATA")
+        base = Path(local) if local else Path.home() / "AppData" / "Local"
+        return base / "ms-playwright"
+    return Path.home() / ".cache" / "ms-playwright"
+
+
+def _chromium_browser_installed() -> bool:
+    """Whether a Chromium build has been fetched (playwright/patchright share it).
+
+    Filesystem-only, no subprocess: looks for a non-empty ``chromium*`` build
+    directory in Playwright's browsers dir. When the location cannot be resolved
+    (``PLAYWRIGHT_BROWSERS_PATH=0``, a bundled install), returns True rather than
+    a false negative — the package is present and the #145 launch smoke-test is
+    the launch-truth backstop; the honest failure direction is never to claim
+    "available" when it is not, and a false "missing" here would do that inverted.
+    """
+    browsers_dir = _playwright_browsers_dir()
+    if browsers_dir is None:
+        return True  # cannot resolve; do not assert "missing" on no evidence
+    try:
+        return any(child.is_dir() and any(child.iterdir()) for child in browsers_dir.glob("chromium*"))
+    except OSError:
+        return True
+
+
+def _camoufox_browser_installed() -> bool:
+    """Whether Camoufox's Firefox build has been fetched, without launching it."""
+    try:
+        from camoufox.pkgman import launch_path
+
+        launch_path()  # raises CamoufoxNotInstalled when the binary is absent
+        return True
+    except Exception:
+        return False
+
+
+def engine_availability(engine: str) -> dict[str, Any]:
+    """Report whether one engine is usable, WITHOUT launching a browser (#144).
+
+    Returns a dict with ``installed`` (package present), ``available`` (package
+    present AND its browser binary fetched), and ``reason`` (None when available,
+    otherwise a coarse ``ENGINE_REASON_*`` category). No internal paths are
+    leaked; an ``install`` hint is included when the engine is unavailable.
+    """
+    if engine not in ENGINE_CHOICES:
+        raise ValueError(f"Invalid engine '{engine}'. Choose from: {', '.join(ENGINE_CHOICES)}")
+    if not _package_installed(_ENGINE_PACKAGE[engine]):
+        return {
+            "installed": False,
+            "available": False,
+            "reason": ENGINE_REASON_NOT_INSTALLED,
+            "install": _ENGINE_INSTALL_HINT[engine],
+        }
+    binary_present = _camoufox_browser_installed() if engine == "camoufox" else _chromium_browser_installed()
+    if not binary_present:
+        return {
+            "installed": True,
+            "available": False,
+            "reason": ENGINE_REASON_BROWSER_NOT_INSTALLED,
+            "install": _ENGINE_INSTALL_HINT[engine],
+        }
+    return {"installed": True, "available": True, "reason": None}
+
+
+def all_engine_availability() -> dict[str, dict[str, Any]]:
+    """Per-engine availability for every stealth tier, no browser launched (#144)."""
+    return {engine: engine_availability(engine) for engine in ENGINE_CHOICES}
+
+
+# --- Container-aware Chromium launch args (#146) -------------------------------
+# Docker's default /dev/shm is 64 MB; Chromium can exhaust it and crash on heavy
+# real pages even when it launches cleanly on a trivial one. --disable-dev-shm-usage
+# makes Chromium use a temp dir on disk instead. Applied only to the Chromium
+# engines (playwright/patchright) — it is a Chromium flag, and Camoufox is Firefox.
+
+
+def _is_containerised() -> bool:
+    """Best-effort detection of running inside a container.
+
+    Checks the two portable signals: Docker's sentinel file and container markers
+    in PID 1's cgroup. Cheap and read-only; any error is treated as "not a
+    container" — the safe default that never adds a flag to a normal desktop run.
+    """
+    try:
+        if os.path.exists("/.dockerenv"):
+            return True
+        cgroup = Path("/proc/1/cgroup")
+        if cgroup.exists():
+            text = cgroup.read_text(errors="ignore")
+            return any(marker in text for marker in ("docker", "containerd", "kubepods", "libpod"))
+    except OSError:
+        pass
+    return False
+
+
+def _should_disable_dev_shm() -> bool:
+    """Whether to pass ``--disable-dev-shm-usage`` to Chromium (#146).
+
+    An explicit ``SUPACRAWL_DISABLE_DEV_SHM`` wins in both directions; otherwise
+    it is on inside a container and off on a normal host.
+    """
+    override = os.getenv("SUPACRAWL_DISABLE_DEV_SHM")
+    if override is not None:
+        return override.strip().lower() in {"1", "true", "yes", "on"}
+    return _is_containerised()
+
+
+def chromium_launch_args() -> list[str]:
+    """Chromium CLI launch args for the current environment (#146).
+
+    Only ``--disable-dev-shm-usage`` is added, and only under a constrained
+    ``/dev/shm`` container. ``--no-sandbox`` is deliberately NOT added here: it
+    weakens the browser sandbox and would regress every non-container user, and a
+    container that needs it sets it in its own launch environment (the downstream
+    Dockerfile already does). Keeping it out of the library is the correct
+    default — it is the one other classic container flag, and it does not belong
+    on by default, so scope is not silently expanded.
+    """
+    args: list[str] = []
+    if _should_disable_dev_shm():
+        args.append("--disable-dev-shm-usage")
+    return args
+
+
 # Domains to skip when expanding iframes (ads, analytics, tracking, CAPTCHA)
 IFRAME_BLOCKED_DOMAINS = frozenset(
     {
@@ -565,6 +745,9 @@ class BrowserManager:
         # until something notices; these track that noticing.
         self._relaunch_lock = asyncio.Lock()
         self._ever_started = False
+        # Distinguishes "never started yet" (lazy-start on first use, #143) from
+        # "deliberately stopped" (a retired manager, not to be resurrected).
+        self._deliberately_stopped = False
         self.relaunches = 0
         self._consecutive_relaunch_failures = 0
         # None, never 0.0: monotonic() starts near process uptime, so 0.0 reads as
@@ -759,6 +942,7 @@ class BrowserManager:
         else:
             await self._start_playwright()
         self._ever_started = True
+        self._deliberately_stopped = False
 
     async def _start_playwright(self) -> None:
         """Start browser via Playwright or Patchright."""
@@ -767,6 +951,12 @@ class BrowserManager:
 
         # Build launch options
         launch_options: dict[str, Any] = {"headless": self.headless}
+
+        # Container-aware Chromium flags (#146): --disable-dev-shm-usage under a
+        # constrained-/dev/shm container so heavy pages do not crash Chromium.
+        launch_args = chromium_launch_args()
+        if launch_args:
+            launch_options["args"] = launch_args
 
         # Add proxy if configured
         if self.proxy:
@@ -841,6 +1031,7 @@ class BrowserManager:
         :meth:`_force_stop`, the relaunch path, keeps the manager live).
         """
         self._ever_started = False
+        self._deliberately_stopped = True
         if self.engine == "camoufox" and hasattr(self, "_camoufox_cm"):
             # Camoufox cleanup via its context manager
             try:
@@ -866,6 +1057,18 @@ class BrowserManager:
         checkout.
         """
         return self._instance_is_alive(self._browser)
+
+    @property
+    def has_launched(self) -> bool:
+        """Whether an engine has ever been launched on this manager.
+
+        With lazy start (#143), a fresh server-side manager has not launched
+        anything until the first tool needs it, so ``is_alive`` is legitimately
+        False without any outage. Health reporting uses this to tell "not started
+        yet" (fine) apart from "started then died" (a real #160 outage), rather
+        than reading an un-launched lazy engine as degraded.
+        """
+        return self._ever_started or self._browser is not None
 
     @staticmethod
     def _instance_is_alive(browser: Any | None) -> bool:
@@ -901,13 +1104,28 @@ class BrowserManager:
         tell a dead engine from a broken site.
 
         Raises:
-            RuntimeError: If the browser was never started, or was deliberately
-                stopped — a programming error, distinct from an engine that died
-                under a running server and can be relaunched.
+            RuntimeError: If the browser was deliberately stopped — a retired
+                manager is a programming error to reuse, distinct from one that
+                has simply never launched (lazy first start) or an engine that
+                died under a running server and can be relaunched.
+            StealthNotAvailableError | CamoufoxNotAvailableError: On lazy first
+                start when the configured stealth engine's package is missing —
+                the typed, per-engine error naming what to install (#143).
             BrowserUnavailableError: If the relaunch failed or is in backoff.
         """
         if self._browser is None and not self._ever_started:
-            raise RuntimeError("Browser not initialized. Use 'async with BrowserManager()' context manager.")
+            if self._deliberately_stopped:
+                raise RuntimeError(
+                    "Browser was stopped and is not initialized. Create a new BrowserManager "
+                    "(or use 'async with BrowserManager()') to use it again."
+                )
+            # Lazy first start (#143): nothing has launched yet. Launch the engine
+            # here, on first real use — not at server startup — so a server whose
+            # configured stealth engine is missing still starts and serves every
+            # non-stealth tool, and only a tool that needs this engine fails, with
+            # the typed per-engine error (Stealth/Camoufox NotAvailableError).
+            await self.start()
+            return
         if self.is_alive:
             return
         LOGGER.warning("Browser engine is not connected before fetch; relaunching in-process")
@@ -986,6 +1204,7 @@ class BrowserManager:
             self._browser = None
             self._playwright = None
             self._ever_started = True
+            self._deliberately_stopped = False
             if hasattr(self, "_camoufox_cm"):
                 del self._camoufox_cm
 

--- a/src/supacrawl/services/browser.py
+++ b/src/supacrawl/services/browser.py
@@ -748,6 +748,11 @@ class BrowserManager:
         # Distinguishes "never started yet" (lazy-start on first use, #143) from
         # "deliberately stopped" (a retired manager, not to be resurrected).
         self._deliberately_stopped = False
+        # Monotonic: True once any engine has launched, and never reset (stop()
+        # clears _ever_started, but a manager that launched-then-stopped is still
+        # "has launched" — health must not read a retired engine as "never
+        # started, fine"). Backs the public has_launched property.
+        self._has_ever_launched = False
         self.relaunches = 0
         self._consecutive_relaunch_failures = 0
         # None, never 0.0: monotonic() starts near process uptime, so 0.0 reads as
@@ -943,6 +948,7 @@ class BrowserManager:
             await self._start_playwright()
         self._ever_started = True
         self._deliberately_stopped = False
+        self._has_ever_launched = True
 
     async def _start_playwright(self) -> None:
         """Start browser via Playwright or Patchright."""
@@ -1066,9 +1072,11 @@ class BrowserManager:
         anything until the first tool needs it, so ``is_alive`` is legitimately
         False without any outage. Health reporting uses this to tell "not started
         yet" (fine) apart from "started then died" (a real #160 outage), rather
-        than reading an un-launched lazy engine as degraded.
+        than reading an un-launched lazy engine as degraded. Monotonic — a manager
+        that launched then stopped still reads True, so a retired engine is never
+        mistaken for one that simply has not started yet.
         """
-        return self._ever_started or self._browser is not None
+        return self._has_ever_launched
 
     @staticmethod
     def _instance_is_alive(browser: Any | None) -> bool:
@@ -1113,21 +1121,33 @@ class BrowserManager:
                 the typed, per-engine error naming what to install (#143).
             BrowserUnavailableError: If the relaunch failed or is in backoff.
         """
+        if self.is_alive:
+            return
         if self._browser is None and not self._ever_started:
-            if self._deliberately_stopped:
-                raise RuntimeError(
-                    "Browser was stopped and is not initialized. Create a new BrowserManager "
-                    "(or use 'async with BrowserManager()') to use it again."
-                )
             # Lazy first start (#143): nothing has launched yet. Launch the engine
             # here, on first real use — not at server startup — so a server whose
             # configured stealth engine is missing still starts and serves every
             # non-stealth tool, and only a tool that needs this engine fails, with
             # the typed per-engine error (Stealth/Camoufox NotAvailableError).
-            await self.start()
-            return
-        if self.is_alive:
-            return
+            #
+            # Serialised on the relaunch lock: a shared server-side manager takes a
+            # burst of concurrent first-use calls (scrape/crawl/map/search all ride
+            # one manager), and an unguarded start would launch one engine PER
+            # caller and orphan every loser. The double-check under the lock lets
+            # the first caller launch while the rest see the started engine.
+            async with self._relaunch_lock:
+                if self.is_alive:
+                    return  # a concurrent first-use caller already launched it
+                if self._browser is None and not self._ever_started:
+                    if self._deliberately_stopped:
+                        raise RuntimeError(
+                            "Browser was stopped and is not initialized. Create a new BrowserManager "
+                            "(or use 'async with BrowserManager()') to use it again."
+                        )
+                    await self.start()
+                    return
+            # Fell through: another caller started it but it is not alive — a start
+            # that raced with an immediate death. Fall to the relaunch path below.
         LOGGER.warning("Browser engine is not connected before fetch; relaunching in-process")
         await self.relaunch()
 

--- a/src/supacrawl/services/diagnose.py
+++ b/src/supacrawl/services/diagnose.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any
 
 import httpx
 
+from supacrawl.services.browser import all_engine_availability
 from supacrawl.services.detection import (
     detect_bot_protection,
     detect_cdn,
@@ -55,6 +56,10 @@ async def supacrawl_diagnose(
         - content_length: Content-Length or actual length
         - indicators: Detection results (CDN, JS framework, bot protection)
         - recommendations: Suggested scrape settings and explanations
+        - engines: Per-engine availability (playwright/patchright/camoufox),
+          each {installed, available, reason}, computed without launching a
+          browser — so you can see which stealth tiers are usable and why one
+          is not
 
     Example:
         # Pre-check before scraping
@@ -79,6 +84,11 @@ async def supacrawl_diagnose(
         "content_length": None,
         "indicators": {},
         "recommendations": {},
+        # Per-engine availability for each stealth tier (#144). Computed WITHOUT
+        # launching a browser, so it is cheap and safe to include on every call;
+        # turns a "scrape failed" mystery into "camoufox unavailable, patchright
+        # OK". URL-independent, hence set before the network probe below.
+        "engines": all_engine_availability(),
     }
 
     try:

--- a/src/supacrawl/services/registry.py
+++ b/src/supacrawl/services/registry.py
@@ -178,8 +178,12 @@ async def create_supacrawl_services(
         engine=config.engine,
     )
 
-    # Initialise browser
-    await browser_manager.start()
+    # Browser startup is deliberately lazy (#143): the engine is launched on the
+    # first tool that actually needs it, not here. This keeps a single missing or
+    # broken stealth engine from cascade-failing the whole server at init — the
+    # server starts and serves every non-browser tool, and a browser tool that
+    # needs an unavailable engine fails on its own with a typed, per-engine error
+    # naming what to install, rather than taking the entire tool surface down.
 
     # Log enabled features
     features = []

--- a/src/supacrawl/services/scrape.py
+++ b/src/supacrawl/services/scrape.py
@@ -45,7 +45,14 @@ from supacrawl.models import (
     ScrapeResult,
 )
 from supacrawl.quality import assess_quality
-from supacrawl.services.browser import BrowserManager, BrowserUnavailableError, PageContent, PageMetadata
+from supacrawl.services.browser import (
+    BrowserManager,
+    BrowserUnavailableError,
+    CamoufoxNotAvailableError,
+    PageContent,
+    PageMetadata,
+    StealthNotAvailableError,
+)
 from supacrawl.services.converter import MarkdownConverter
 from supacrawl.services.detection import detect_bot_protection, estimate_js_requirement
 from supacrawl.services.http_fetch import fetch_static
@@ -247,6 +254,24 @@ def _is_camoufox_available() -> bool:
         return True
     except ImportError:
         return False
+
+
+def _engine_available(engine: str | None) -> bool:
+    """Whether an engine can be used, i.e. its package is installed (#143).
+
+    ``playwright`` is a base dependency and always available. Guards escalation
+    choices — a platform short-circuit or a learned strategy-memory champion —
+    from picking a stealth engine that is not installed, which would otherwise
+    turn a scrape into a clear-but-avoidable infrastructure failure instead of
+    degrading to the engine that IS present.
+    """
+    if engine in (None, "playwright"):
+        return True
+    if engine == "patchright":
+        return _is_patchright_available()
+    if engine == "camoufox":
+        return _is_camoufox_available()
+    return False
 
 
 def _stealth_hint(*, bot_suspected: bool = False) -> str:
@@ -522,8 +547,16 @@ def _next_escalation(
     if pinned:
         return None
 
-    # A known site builder: escalate straight to its tuned engine/settings.
-    if platform is not None and platform.engine and platform.engine != (engine or "playwright"):
+    # A known site builder: escalate straight to its tuned engine/settings — but
+    # only if that engine is actually installed (#143). A tuned engine that is
+    # missing must not be chosen: doing so would fail the scrape on an
+    # infrastructure error instead of degrading to the generic ladder below.
+    if (
+        platform is not None
+        and platform.engine
+        and platform.engine != (engine or "playwright")
+        and _engine_available(platform.engine)
+    ):
         return _Rung(
             platform.engine,
             stealth,
@@ -918,6 +951,17 @@ class ScrapeService:
         seed: StrategyChoice | None = None
         if memory_domain and self._strategy_store is not None and not user_pinned and _escalation_level == 0:
             seed = self._strategy_store.seed(memory_domain)
+            # A champion learned on a machine that had the engine, replayed where
+            # that engine is no longer installed, would hard-fail every hit to the
+            # domain (#143). Drop a stale seed so the request degrades to the
+            # default engine instead of cascade-failing on the missing one.
+            if seed is not None and not _engine_available(seed.engine):
+                LOGGER.debug(
+                    "Champion engine %r for %s is not installed; ignoring stale strategy seed",
+                    seed.engine,
+                    memory_domain,
+                )
+                seed = None
 
         attempt_engine = effective_engine
         attempt_stealth = self._stealth
@@ -1355,7 +1399,14 @@ class ScrapeService:
         """
         error_msg = str(error)
         low_error = error_msg.lower()
-        scraper_fault = isinstance(error, BrowserUnavailableError)
+        # A missing/broken stealth engine is a scraper-environment fault, not a
+        # site problem (#143): its typed error already names the engine and how to
+        # install it, so classify it alongside BrowserUnavailableError as
+        # INFRASTRUCTURE rather than letting it fall through to a misleading EMPTY
+        # verdict that reads as "the site returned nothing".
+        scraper_fault = isinstance(
+            error, (BrowserUnavailableError, StealthNotAvailableError, CamoufoxNotAvailableError)
+        )
         bot_suspected = not scraper_fault and any(p in low_error for p in ["403", "429", "blocked", "denied"])
         if scraper_fault:
             # A stealth or wait hint would be actively misleading here: nothing

--- a/src/supacrawl/services/scrape.py
+++ b/src/supacrawl/services/scrape.py
@@ -52,6 +52,7 @@ from supacrawl.services.browser import (
     PageContent,
     PageMetadata,
     StealthNotAvailableError,
+    engine_availability,
 )
 from supacrawl.services.converter import MarkdownConverter
 from supacrawl.services.detection import detect_bot_protection, estimate_js_requirement
@@ -257,20 +258,26 @@ def _is_camoufox_available() -> bool:
 
 
 def _engine_available(engine: str | None) -> bool:
-    """Whether an engine can be used, i.e. its package is installed (#143).
+    """Whether an engine can actually be used for an escalation choice (#143).
 
-    ``playwright`` is a base dependency and always available. Guards escalation
-    choices — a platform short-circuit or a learned strategy-memory champion —
-    from picking a stealth engine that is not installed, which would otherwise
-    turn a scrape into a clear-but-avoidable infrastructure failure instead of
-    degrading to the engine that IS present.
+    Guards a platform short-circuit or a learned strategy-memory champion from
+    picking a stealth engine that cannot launch — which would otherwise turn a
+    scrape into a clear-but-avoidable infrastructure failure instead of degrading
+    to the engine that IS present. Uses the same binary-aware check that
+    supacrawl_diagnose reports (#144): a package installed but with its browser
+    binary not fetched (a bare ``uv sync`` / no ``patchright install`` /
+    ``camoufox fetch``) is NOT usable, and must be skipped just like a missing
+    package — otherwise the launch fails with a raw "executable not found" that
+    is not one of the typed engine errors and misclassifies as EMPTY.
+
+    ``playwright`` is the base fallback and is never gated here (the ladder never
+    skips its own floor); its own binary health surfaces via diagnose and, on a
+    real launch, the lazy-start/relaunch path.
     """
     if engine in (None, "playwright"):
         return True
-    if engine == "patchright":
-        return _is_patchright_available()
-    if engine == "camoufox":
-        return _is_camoufox_available()
+    if engine in ("patchright", "camoufox"):
+        return bool(engine_availability(engine)["available"])
     return False
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -103,6 +103,11 @@ def pytest_configure(config: pytest.Config) -> None:
         "markers",
         "e2e: End-to-end tests with live network, Playwright, or external services",
     )
+    config.addinivalue_line(
+        "markers",
+        "stealth_smoke: Launches a real stealth engine headless (#145); run in a dedicated CI job "
+        "that fetches every engine's browser binary, excluded from the main test job.",
+    )
 
 
 def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
@@ -116,7 +121,7 @@ def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item
         # Skip if already has a category marker
         markers = list(item.iter_markers())
         marker_names = [m.name for m in markers]
-        if any(m in marker_names for m in ("unit", "integration", "e2e")):
+        if any(m in marker_names for m in ("unit", "integration", "e2e", "stealth_smoke")):
             continue
 
         # Default unmarked tests to unit

--- a/tests/test_engine_availability.py
+++ b/tests/test_engine_availability.py
@@ -1,0 +1,102 @@
+"""#144 — per-engine availability reported WITHOUT launching a browser.
+
+``supacrawl_diagnose`` reports, per stealth tier (playwright / patchright /
+camoufox), whether the engine is usable and why not — cheaply and safely, with
+no browser process started. The launch-truth backstop that an "available"
+verdict is honest (not a confident liar, the supacrawl#158 class) lives in
+``test_engine_smoke.py`` (#145), which actually launches each engine.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from supacrawl.services import browser as browser_mod
+from supacrawl.services.browser import (
+    ENGINE_REASON_BROWSER_NOT_INSTALLED,
+    ENGINE_REASON_NOT_INSTALLED,
+    BrowserManager,
+    all_engine_availability,
+    engine_availability,
+)
+
+
+class TestEngineAvailability:
+    def test_every_stealth_tier_has_a_verdict(self) -> None:
+        report = all_engine_availability()
+        assert set(report) == {"playwright", "patchright", "camoufox"}
+        for engine, verdict in report.items():
+            assert set(verdict) >= {"installed", "available", "reason"}, engine
+            assert isinstance(verdict["available"], bool)
+
+    def test_a_missing_package_is_reported_not_installed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Mask camoufox's package as absent without touching the others.
+        real = browser_mod._package_installed
+        monkeypatch.setattr(
+            browser_mod,
+            "_package_installed",
+            lambda pkg: False if pkg == "camoufox" else real(pkg),
+        )
+        verdict = engine_availability("camoufox")
+        assert verdict["installed"] is False
+        assert verdict["available"] is False
+        assert verdict["reason"] == ENGINE_REASON_NOT_INSTALLED
+        assert "install" in verdict  # actionable hint present
+
+    def test_package_present_but_binary_missing_is_reported(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(browser_mod, "_package_installed", lambda pkg: True)
+        monkeypatch.setattr(browser_mod, "_chromium_browser_installed", lambda: False)
+        verdict = engine_availability("patchright")
+        assert verdict["installed"] is True
+        assert verdict["available"] is False
+        assert verdict["reason"] == ENGINE_REASON_BROWSER_NOT_INSTALLED
+
+    def test_a_fully_present_engine_is_available(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(browser_mod, "_package_installed", lambda pkg: True)
+        monkeypatch.setattr(browser_mod, "_chromium_browser_installed", lambda: True)
+        monkeypatch.setattr(browser_mod, "_camoufox_browser_installed", lambda: True)
+        for engine in ("playwright", "patchright", "camoufox"):
+            verdict = engine_availability(engine)
+            assert verdict == {"installed": True, "available": True, "reason": None}, engine
+
+    def test_availability_never_launches_a_browser(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The observable proof for #144: computing availability starts no engine."""
+
+        def _boom(*_a: Any, **_k: Any) -> None:
+            raise AssertionError("availability check must not launch/start a browser")
+
+        # Poison every launch/start seam.
+        monkeypatch.setattr(BrowserManager, "start", _boom)
+        monkeypatch.setattr(BrowserManager, "_start_playwright", _boom)
+        monkeypatch.setattr(BrowserManager, "_start_camoufox", _boom)
+
+        report = all_engine_availability()  # must not raise
+        assert set(report) == {"playwright", "patchright", "camoufox"}
+
+
+class TestDiagnoseEngines:
+    @pytest.mark.asyncio
+    async def test_diagnose_reports_engines_without_launching(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from supacrawl.services import diagnose as diagnose_mod
+
+        # Stub the network probe so the test is offline and deterministic.
+        async def _fake_request(client: Any, method: str, url: str) -> Any:
+            raise RuntimeError("network disabled in test")
+
+        monkeypatch.setattr(diagnose_mod, "guarded_request", _fake_request)
+
+        def _boom(*_a: Any, **_k: Any) -> None:
+            raise AssertionError("diagnose must not launch a browser")
+
+        monkeypatch.setattr(BrowserManager, "start", _boom)
+        monkeypatch.setattr(BrowserManager, "_start_playwright", _boom)
+        monkeypatch.setattr(BrowserManager, "_start_camoufox", _boom)
+
+        result = await diagnose_mod.supacrawl_diagnose(api_client=None, url="https://example.com")  # type: ignore[arg-type]
+
+        engines = result["diagnosis"]["engines"]
+        assert set(engines) == {"playwright", "patchright", "camoufox"}
+        for verdict in engines.values():
+            assert set(verdict) >= {"installed", "available", "reason"}

--- a/tests/test_engine_resilience.py
+++ b/tests/test_engine_resilience.py
@@ -74,6 +74,34 @@ class TestLazyStart:
         assert started["count"] == 1  # launched lazily on first use
 
     @pytest.mark.asyncio
+    async def test_concurrent_first_use_launches_exactly_one_engine(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A burst of concurrent first-use must launch ONE engine, not one per caller.
+
+        The shared server-side manager is hit by scrape/crawl/map/search at once
+        on a just-booted server; an unguarded lazy start would launch a browser
+        per caller and orphan every loser (a real regression from moving startup
+        off the synchronous init path).
+        """
+        import asyncio
+
+        started = {"count": 0}
+
+        async def _slow_start(self: BrowserManager) -> None:
+            # Yield so all callers pile up on the lazy branch before any completes.
+            await asyncio.sleep(0.02)
+            started["count"] += 1
+            self._browser = object()  # type: ignore[assignment]
+            self._ever_started = True
+
+        monkeypatch.setattr(BrowserManager, "start", _slow_start)
+        monkeypatch.setattr(BrowserManager, "is_alive", property(lambda self: self._browser is not None))
+
+        manager = BrowserManager()
+        await asyncio.gather(*(manager.ensure_started() for _ in range(8)))
+
+        assert started["count"] == 1, "concurrent first use must launch exactly one engine"
+
+    @pytest.mark.asyncio
     async def test_missing_stealth_engine_raises_typed_error_on_use_not_at_construction(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -123,21 +151,24 @@ class TestMissingEngineClassification:
         assert "camoufox" in result.error.lower()
 
 
+class _Platform:
+    name = "foleon"
+    engine = "camoufox"
+    wait_for = 8000
+    only_main_content = False
+    expand_iframes = "all"
+    actions: list[Any] = []
+
+
 class TestEscalationAvailabilityGating:
     def test_platform_short_circuit_skips_an_uninstalled_engine(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """A tuned platform engine that is missing must not be chosen (#143)."""
         from supacrawl.services import scrape as scrape_mod
 
-        class _Platform:
-            name = "foleon"
-            engine = "camoufox"
-            wait_for = 8000
-            only_main_content = False
-            expand_iframes = "all"
-            actions: list[Any] = []
-
-        # camoufox unavailable → the platform rung must be skipped; with nothing
-        # else installed either, the ladder yields None rather than a camoufox rung.
+        # camoufox unavailable (both the binary-aware gate and the generic-ladder
+        # import checks) → the platform rung is skipped and nothing else is
+        # installed, so the ladder yields None rather than a camoufox rung.
+        monkeypatch.setattr(scrape_mod, "engine_availability", lambda engine: {"available": False})
         monkeypatch.setattr(scrape_mod, "_is_camoufox_available", lambda: False)
         monkeypatch.setattr(scrape_mod, "_is_patchright_available", lambda: False)
         rung = scrape_mod._next_escalation(
@@ -148,14 +179,7 @@ class TestEscalationAvailabilityGating:
     def test_platform_short_circuit_used_when_engine_is_installed(self, monkeypatch: pytest.MonkeyPatch) -> None:
         from supacrawl.services import scrape as scrape_mod
 
-        class _Platform:
-            name = "foleon"
-            engine = "camoufox"
-            wait_for = 8000
-            only_main_content = False
-            expand_iframes = "all"
-            actions: list[Any] = []
-
+        monkeypatch.setattr(scrape_mod, "engine_availability", lambda engine: {"available": True})
         monkeypatch.setattr(scrape_mod, "_is_camoufox_available", lambda: True)
         monkeypatch.setattr(scrape_mod, "_is_patchright_available", lambda: True)
         rung = scrape_mod._next_escalation(
@@ -163,6 +187,36 @@ class TestEscalationAvailabilityGating:
         )
         assert rung is not None
         assert rung.engine == "camoufox"
+
+    def test_gate_skips_a_package_present_but_binary_missing_engine(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The #144/#143 join: an installed package with no browser binary is NOT usable.
+
+        This is the common real misconfiguration (a bare ``uv sync``, or no
+        ``patchright install`` / ``camoufox fetch``). It must be skipped exactly
+        like a missing package, or the launch fails with a raw "executable not
+        found" that misclassifies as EMPTY instead of degrading.
+        """
+        from supacrawl.services import browser as browser_mod
+        from supacrawl.services import scrape as scrape_mod
+
+        # Package present, browser binary absent — the binary-aware check the gate
+        # now uses must report the engine unusable.
+        monkeypatch.setattr(browser_mod, "_package_installed", lambda pkg: True)
+        monkeypatch.setattr(browser_mod, "_chromium_browser_installed", lambda: False)
+        monkeypatch.setattr(browser_mod, "_camoufox_browser_installed", lambda: False)
+
+        assert scrape_mod._engine_available("patchright") is False
+        assert scrape_mod._engine_available("camoufox") is False
+        # The base engine is never gated away.
+        assert scrape_mod._engine_available("playwright") is True
+
+        # And the platform short-circuit therefore skips the binary-missing engine.
+        monkeypatch.setattr(scrape_mod, "_is_camoufox_available", lambda: False)
+        monkeypatch.setattr(scrape_mod, "_is_patchright_available", lambda: False)
+        rung = scrape_mod._next_escalation(
+            engine="playwright", stealth=False, prefs=None, pinned=False, http2_error=False, platform=_Platform()
+        )
+        assert rung is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_engine_resilience.py
+++ b/tests/test_engine_resilience.py
@@ -1,0 +1,218 @@
+"""Stealth-engine resilience and container-aware Chromium launch args.
+
+Covers the engine-layer hardening lane:
+- #143: a missing stealth engine degrades gracefully (lazy start; non-stealth
+  tools keep working; a stealth path fails with a typed, per-engine error), and
+  never cascade-fails the whole server at startup.
+- #146: Chromium launch args include ``--disable-dev-shm-usage`` under a
+  constrained-/dev/shm container, gated so a normal host is not regressed.
+
+Per-engine availability reporting (#144) is in ``test_engine_availability.py``;
+the real-launch backstop (#145) is in ``test_engine_smoke.py``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from supacrawl.services import browser as browser_mod
+from supacrawl.services.browser import (
+    BrowserManager,
+    CamoufoxNotAvailableError,
+    StealthNotAvailableError,
+    chromium_launch_args,
+)
+
+# ---------------------------------------------------------------------------
+# #143 — graceful degradation: lazy start + typed per-engine error
+# ---------------------------------------------------------------------------
+
+
+class TestLazyStart:
+    @pytest.mark.asyncio
+    async def test_server_factory_does_not_launch_a_browser_at_startup(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Any
+    ) -> None:
+        """#143 criterion: no engine is launched until a tool needs one."""
+        from supacrawl.services import registry
+
+        started = {"count": 0}
+
+        async def _record_start(self: BrowserManager) -> None:
+            started["count"] += 1
+
+        monkeypatch.setattr(BrowserManager, "start", _record_start)
+        monkeypatch.setenv("SUPACRAWL_CACHE_DIR", str(tmp_path / "cache"))
+
+        services = await registry.create_supacrawl_services()
+        try:
+            assert started["count"] == 0, "the server must not launch the engine at init"
+            # The full non-stealth tool surface is still wired and usable.
+            assert services.scrape_service is not None
+            assert services.search_service is not None
+            assert services.map_service is not None
+        finally:
+            await services.close()
+
+    @pytest.mark.asyncio
+    async def test_first_fetch_triggers_lazy_start(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        started = {"count": 0}
+
+        async def _record_start(self: BrowserManager) -> None:
+            started["count"] += 1
+            self._browser = object()  # type: ignore[assignment]
+            self._ever_started = True
+
+        monkeypatch.setattr(BrowserManager, "start", _record_start)
+        monkeypatch.setattr(BrowserManager, "is_alive", property(lambda self: self._browser is not None))
+
+        manager = BrowserManager()
+        assert started["count"] == 0  # nothing launched by construction
+        await manager.ensure_started()
+        assert started["count"] == 1  # launched lazily on first use
+
+    @pytest.mark.asyncio
+    async def test_missing_stealth_engine_raises_typed_error_on_use_not_at_construction(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Construction never launches, so it must not raise even for a missing engine.
+        manager = BrowserManager(engine="camoufox")
+
+        async def _missing(self: BrowserManager) -> None:
+            raise CamoufoxNotAvailableError()
+
+        monkeypatch.setattr(BrowserManager, "_start_camoufox", _missing)
+        with pytest.raises(CamoufoxNotAvailableError):
+            await manager.ensure_started()
+
+
+class TestMissingEngineClassification:
+    """A missing-engine failure is INFRASTRUCTURE (scraper fault), not a site EMPTY."""
+
+    def _service(self) -> Any:
+        from supacrawl.services.scrape import ScrapeService
+
+        return ScrapeService()
+
+    def test_stealth_missing_is_infrastructure_and_names_the_engine(self) -> None:
+        from supacrawl.models import QualityVerdict
+
+        result = self._service()._build_failure_result(
+            url="https://x.test",
+            error=StealthNotAvailableError(),
+            wants_change_tracking=False,
+            previous_entry=None,
+        )
+        assert result.success is False
+        assert result.quality.verdict == QualityVerdict.INFRASTRUCTURE
+        assert "patchright" in result.error  # names what to install
+        assert "supacrawl[stealth]" in result.error
+
+    def test_camoufox_missing_is_infrastructure(self) -> None:
+        from supacrawl.models import QualityVerdict
+
+        result = self._service()._build_failure_result(
+            url="https://x.test",
+            error=CamoufoxNotAvailableError(),
+            wants_change_tracking=False,
+            previous_entry=None,
+        )
+        assert result.quality.verdict == QualityVerdict.INFRASTRUCTURE
+        assert "camoufox" in result.error.lower()
+
+
+class TestEscalationAvailabilityGating:
+    def test_platform_short_circuit_skips_an_uninstalled_engine(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A tuned platform engine that is missing must not be chosen (#143)."""
+        from supacrawl.services import scrape as scrape_mod
+
+        class _Platform:
+            name = "foleon"
+            engine = "camoufox"
+            wait_for = 8000
+            only_main_content = False
+            expand_iframes = "all"
+            actions: list[Any] = []
+
+        # camoufox unavailable → the platform rung must be skipped; with nothing
+        # else installed either, the ladder yields None rather than a camoufox rung.
+        monkeypatch.setattr(scrape_mod, "_is_camoufox_available", lambda: False)
+        monkeypatch.setattr(scrape_mod, "_is_patchright_available", lambda: False)
+        rung = scrape_mod._next_escalation(
+            engine="playwright", stealth=False, prefs=None, pinned=False, http2_error=False, platform=_Platform()
+        )
+        assert rung is None
+
+    def test_platform_short_circuit_used_when_engine_is_installed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from supacrawl.services import scrape as scrape_mod
+
+        class _Platform:
+            name = "foleon"
+            engine = "camoufox"
+            wait_for = 8000
+            only_main_content = False
+            expand_iframes = "all"
+            actions: list[Any] = []
+
+        monkeypatch.setattr(scrape_mod, "_is_camoufox_available", lambda: True)
+        monkeypatch.setattr(scrape_mod, "_is_patchright_available", lambda: True)
+        rung = scrape_mod._next_escalation(
+            engine="playwright", stealth=False, prefs=None, pinned=False, http2_error=False, platform=_Platform()
+        )
+        assert rung is not None
+        assert rung.engine == "camoufox"
+
+
+# ---------------------------------------------------------------------------
+# #146 — container-gated Chromium launch args
+# ---------------------------------------------------------------------------
+
+
+class TestChromiumLaunchArgs:
+    def test_explicit_env_on_adds_the_flag(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("SUPACRAWL_DISABLE_DEV_SHM", "1")
+        assert "--disable-dev-shm-usage" in chromium_launch_args()
+
+    def test_explicit_env_off_wins_even_in_a_container(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("SUPACRAWL_DISABLE_DEV_SHM", "0")
+        monkeypatch.setattr(browser_mod, "_is_containerised", lambda: True)
+        assert chromium_launch_args() == []
+
+    def test_container_detected_adds_the_flag(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("SUPACRAWL_DISABLE_DEV_SHM", raising=False)
+        monkeypatch.setattr(browser_mod, "_is_containerised", lambda: True)
+        assert chromium_launch_args() == ["--disable-dev-shm-usage"]
+
+    def test_normal_host_is_not_regressed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("SUPACRAWL_DISABLE_DEV_SHM", raising=False)
+        monkeypatch.setattr(browser_mod, "_is_containerised", lambda: False)
+        assert chromium_launch_args() == []
+
+    @pytest.mark.asyncio
+    async def test_flag_is_wired_into_the_chromium_launch(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The configured launch options actually carry the flag (#146)."""
+        monkeypatch.setenv("SUPACRAWL_DISABLE_DEV_SHM", "1")
+        captured: dict[str, Any] = {}
+
+        class _FakeChromium:
+            async def launch(self, **kwargs: Any) -> Any:
+                captured.update(kwargs)
+                return object()
+
+        class _FakePlaywright:
+            chromium = _FakeChromium()
+
+            async def stop(self) -> None:
+                return None
+
+        class _FakeAsyncPlaywright:
+            async def start(self) -> _FakePlaywright:
+                return _FakePlaywright()
+
+        manager = BrowserManager(engine="playwright", headless=True)
+        monkeypatch.setattr(manager, "_get_playwright_module", lambda: lambda: _FakeAsyncPlaywright())
+        await manager._start_playwright()
+
+        assert "--disable-dev-shm-usage" in captured.get("args", [])

--- a/tests/test_engine_smoke.py
+++ b/tests/test_engine_smoke.py
@@ -1,0 +1,77 @@
+"""#145 — CI smoke-test that each stealth engine actually launches headless.
+
+The deliverable is the launch check itself. Each engine (playwright / patchright
+Chromium, camoufox Firefox) is launched headless against a trivial loopback page;
+if an engine cannot launch — package missing, browser binary not fetched, version
+skew — the test FAILS. This is what makes the #144 no-launch availability report
+trustworthy rather than a confident liar: something independently proves that an
+engine reported "available" can in fact start.
+
+Marked ``stealth_smoke`` and excluded from the main test job, because it needs
+every engine's browser binary fetched (``camoufox fetch`` especially, which the
+main job does not run). A dedicated CI job installs the stealth+camoufox extras,
+fetches all browsers, and runs ``pytest -m stealth_smoke`` — a red here gates the
+merge, catching a broken stealth engine in supacrawl's own pipeline instead of
+downstream at a consumer's container build.
+
+To confirm it can go RED (not merely green today): temporarily point an engine at
+a missing binary, e.g.
+    PLAYWRIGHT_BROWSERS_PATH=/nonexistent uv run pytest -m stealth_smoke
+and observe the Chromium engines fail to launch.
+"""
+
+from __future__ import annotations
+
+import http.server
+import threading
+
+import pytest
+
+from supacrawl.services.browser import BrowserManager, engine_availability
+
+_PROBE_BODY = b"<html><body><h1>engine-smoke</h1><p>launched headless</p></body></html>"
+
+
+def _serve_probe_page() -> tuple[http.server.HTTPServer, int]:
+    """A loopback HTTP server so the smoke test needs no external network."""
+
+    class Handler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler's contract
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html")
+            self.send_header("Content-Length", str(len(_PROBE_BODY)))
+            self.end_headers()
+            self.wfile.write(_PROBE_BODY)
+
+        def log_message(self, *args: object) -> None:
+            pass
+
+    server = http.server.HTTPServer(("127.0.0.1", 0), Handler)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    return server, server.server_address[1]
+
+
+@pytest.mark.stealth_smoke
+@pytest.mark.asyncio
+@pytest.mark.parametrize("engine", ["playwright", "patchright", "camoufox"])
+async def test_engine_launches_headless_and_serves_a_page(engine: str) -> None:
+    """Each stealth engine must launch headless and return real page content.
+
+    No skip-if-missing: in the dedicated smoke job every engine is expected to be
+    fully installed, so an unavailable engine is a genuine failure to surface, not
+    a reason to pass quietly. The availability check is asserted first so a
+    binary-missing engine fails with a precise reason before the launch attempt.
+    """
+    verdict = engine_availability(engine)
+    assert verdict["available"], f"{engine} not available: {verdict}"
+
+    server, port = _serve_probe_page()
+    url = f"http://127.0.0.1:{port}/"
+    try:
+        async with BrowserManager(engine=engine, headless=True) as browser:
+            assert browser.is_alive is True, f"{engine} did not stay connected after launch"
+            content = await browser.fetch_page(url, wait_for_spa=False)
+            assert "engine-smoke" in content.html, f"{engine} launched but returned no content"
+            assert content.status_code == 200
+    finally:
+        server.shutdown()

--- a/tests/test_mcp/test_health_browser_liveness.py
+++ b/tests/test_mcp/test_health_browser_liveness.py
@@ -68,3 +68,25 @@ async def test_a_server_with_no_shared_engine_reports_no_liveness_claim() -> Non
 
     assert "alive" not in result["components"]["browser"]
     assert result["status"] == "healthy"
+
+
+async def test_a_lazily_unlaunched_engine_is_not_degraded() -> None:
+    """A fresh server whose lazy engine has not launched yet is NOT an outage (#143).
+
+    With lazy start, ``is_alive`` is False until the first scrape. That must read
+    as "not started yet" (healthy), distinct from a launched engine that died —
+    otherwise every just-booted server would falsely report degraded, the same
+    confident-liar failure class the health surface exists to prevent.
+    """
+    from supacrawl.services.browser import BrowserManager
+
+    manager = BrowserManager()  # constructed, never started
+    assert manager.has_launched is False
+
+    result = await supacrawl_health(_StubServices(manager), verify_search=False)  # type: ignore[arg-type]
+
+    browser = result["components"]["browser"]
+    assert browser["launched"] is False
+    assert browser["alive"] is False
+    assert "warning" not in browser
+    assert result["status"] == "healthy"


### PR DESCRIPTION
Closes #143, #154, #144, #145, #146 — WP-91, one coherent defect: the engine layer failed in a cascade, couldn't be diagnosed without launching a browser, and nothing in CI proved an engine actually starts.

## What changed

**#143 / #154 — graceful degradation (the spine).** The browser now starts *lazily* on the first tool that needs it, not eagerly in `create_supacrawl_services()`. A configured-but-missing stealth engine no longer zeroes out the whole MCP server — every non-stealth tool keeps working, and a stealth tool fails on its own with the typed, per-engine error naming what to install. `StealthNotAvailableError` / `CamoufoxNotAvailableError` now classify as `INFRASTRUCTURE`, not a misleading `EMPTY` "site returned nothing". A stale strategy-memory champion or a platform short-circuit that names an uninstalled engine degrades to the engine that *is* present instead of hard-failing the domain.

**#144 — per-engine availability in `supacrawl_diagnose`, no browser launched.** Reports `installed` / `available` / `reason` for each tier. Chromium binary checked on disk; camoufox via its own `launch_path()`; neither starts a process. Turns "everything is broken" into "camoufox unavailable, patchright OK".

**#145 — CI smoke-test that each engine launches headless.** A dedicated `stealth-smoke` job fetches every engine's browser binary and launches playwright/patchright Chromium and camoufox Firefox against a trivial loopback page. Proven to go **red** when a binary is absent (`PLAYWRIGHT_BROWSERS_PATH=/nonexistent`). This is the launch-truth backstop that keeps the #144 no-launch report honest — the same failure class as #158 (health reporting ready while serving from an unconfigured provider), kept out of the engine layer.

**#146 — `--disable-dev-shm-usage`.** Added to Chromium launch args under a constrained-`/dev/shm` container (auto-detected; `SUPACRAWL_DISABLE_DEV_SHM` overrides both ways). `--no-sandbox` was reviewed and deliberately **not** added — it weakens the sandbox for every non-container user; a container that needs it sets it in its own launch environment.

Health reporting learned lazy-awareness: a never-launched engine reads "not started yet", not degraded.

## Proof (driven, not mocked)

- Masking camoufox's *package* (a genuine meta-path block, not a mock): non-stealth playwright scrapes still return content; the camoufox path fails `INFRASTRUCTURE` naming the engine; availability flips to `not_installed` with **no browser launched**.
- The smoke-test fails when the Chromium binary is masked, and the #144 availability check independently agrees (`browser_not_installed`) — the coupling holds.
- Full suite: 1501 passed (+3 stealth-smoke), ruff + mypy clean, live scrape through the edited tree confirmed.

## Notes
- #144 and #146 ride in the library commit with #143 because they share `browser.py` and can't be cleanly hunk-split; #145 (CI) is the separable second commit.