### PR TITLE
fix(engine,crawl): fail fast on captcha, seed crawl browser from champion (#153 #139 #150)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -178,8 +178,8 @@ jobs:
 
       # ntfy-failure inlined (public repo, see lint/typecheck jobs above); this
       # job runs on ubuntu-latest so the atlas host token files below don't
-      # exist — falls through to secrets.NTFY_TOKEN, which is unset for this
-      # repo today (warns and no-ops rather than failing the job).
+      # exist — falls through to secrets.NTFY_TOKEN, provisioned for this repo
+      # (#150) so a red main run pages the infra topic.
       - name: Notify failure (ntfy infra)
         if: failure() && github.event_name != 'pull_request'
         shell: bash

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -50,6 +50,7 @@ Every setting is a standing default; a per-request flag or API argument still ov
 | anti_bot | `stealth` | `SUPACRAWL_STEALTH` | `false` | Start with Patchright. Usually unnecessary. |
 | anti_bot | `escalate` | `SUPACRAWL_ESCALATE` | `true` | Auto-climb the engine/stealth ladder on a poor result. |
 | anti_bot | `solve_captcha` | `SUPACRAWL_SOLVE_CAPTCHA` | `false` | Needs a CAPTCHA API key; each solve costs money. |
+| anti_bot | _(env only)_ | `SUPACRAWL_CAPTCHA_FAIL_FAST` | `true` | Stop after one attempt on a bare CAPTCHA wall instead of walking the whole engine ladder — a stronger engine does not solve a CAPTCHA, so the three further escalations are wasted (#153). A CAPTCHA inside a CDN managed-challenge interstitial (Cloudflare "just a moment") is a `bot_challenge`, not a `captcha`, and still escalates. Set `0` to restore the full-ladder walk. |
 | content | `only_main_content` | `SUPACRAWL_ONLY_MAIN_CONTENT` | `true` | Strip nav/header/footer. |
 | search | `search_providers` | `SUPACRAWL_SEARCH_PROVIDERS` | _(none)_ | Ordered fallback chain, e.g. `brave,tavily,serper`. |
 | search | `search_provider` | `SUPACRAWL_SEARCH_PROVIDER` | `brave` | Legacy single provider. |

--- a/src/supacrawl/quality.py
+++ b/src/supacrawl/quality.py
@@ -318,12 +318,15 @@ def _classify(
     # (e.g. a comment form) still extracted fine.
     if indicators["captcha_present"] and word_count < _THIN_WORD_FLOOR:
         # A CAPTCHA widget wrapped in a CDN "managed challenge" interstitial
-        # (Cloudflare "just a moment"/Turnstile, or an access-denied block) is
+        # (Cloudflare "just a moment"/"checking your browser"/challenge-form) is
         # passable by a stealth engine, so it stays a BOT_CHALLENGE and keeps
-        # escalating. A bare CAPTCHA widget with no interstitial is a hard
-        # third-party wall (reCAPTCHA/hCaptcha) that a stronger engine will not
-        # defeat — it is a CAPTCHA, and the ladder fails fast on it (#153).
-        if challenge:
+        # escalating. A bare CAPTCHA widget is a hard third-party wall
+        # (reCAPTCHA/hCaptcha) that a stronger engine will not defeat — it is a
+        # CAPTCHA, and the ladder fails fast on it (#153). Key off
+        # challenge_detected only, NOT access_denied: an "access denied"/"blocked"
+        # page carrying a bare CAPTCHA is a terminal wall, not a passable
+        # interstitial, and must keep failing fast.
+        if indicators["challenge_detected"]:
             return QualityVerdict.BOT_CHALLENGE, [
                 "CAPTCHA inside an anti-bot challenge interstitial with no usable content"
             ]

--- a/src/supacrawl/quality.py
+++ b/src/supacrawl/quality.py
@@ -317,6 +317,16 @@ def _classify(
     # content came through — a content page that merely embeds a CAPTCHA widget
     # (e.g. a comment form) still extracted fine.
     if indicators["captcha_present"] and word_count < _THIN_WORD_FLOOR:
+        # A CAPTCHA widget wrapped in a CDN "managed challenge" interstitial
+        # (Cloudflare "just a moment"/Turnstile, or an access-denied block) is
+        # passable by a stealth engine, so it stays a BOT_CHALLENGE and keeps
+        # escalating. A bare CAPTCHA widget with no interstitial is a hard
+        # third-party wall (reCAPTCHA/hCaptcha) that a stronger engine will not
+        # defeat — it is a CAPTCHA, and the ladder fails fast on it (#153).
+        if challenge:
+            return QualityVerdict.BOT_CHALLENGE, [
+                "CAPTCHA inside an anti-bot challenge interstitial with no usable content"
+            ]
         return QualityVerdict.CAPTCHA, ["CAPTCHA challenge present with no usable content"]
     if challenge and word_count < _THIN_WORD_FLOOR:
         return QualityVerdict.BOT_CHALLENGE, ["anti-bot challenge fingerprint with no usable content"]

--- a/src/supacrawl/services/crawl.py
+++ b/src/supacrawl/services/crawl.py
@@ -236,13 +236,43 @@ class CrawlService:
                 ):
                     yield event
             else:
+                # Crawl-level shared-engine seeding (#139): a crawl shares ONE
+                # browser across pages. If the start domain's learned champion
+                # needs a stronger engine than the default (camoufox / stealth),
+                # build the shared browser with it once, so every same-domain page
+                # reuses one strong browser instead of the per-page seed path
+                # spinning up a temporary stealth browser per page. Uses the
+                # exploration-free ``get`` (not ``seed``), so the shared engine is
+                # the deterministic champion and the per-page seeds match it — the
+                # coordination the issue flagged: no shared pin fighting a per-page
+                # explore. A user-pinned engine/stealth still wins over memory.
+                seed_engine, seed_stealth = engine, stealth
+                if self._strategy_store is not None and engine is None and not stealth:
+                    from supacrawl.services.scrape import _engine_available
+                    from supacrawl.services.strategy_memory import _engine_cost, registrable_domain
+
+                    start_domain = registrable_domain(url)
+                    champion = self._strategy_store.get(start_domain) if start_domain else None
+                    if (
+                        champion is not None
+                        and _engine_cost(champion.engine, champion.stealth) > 0
+                        and _engine_available(champion.engine)
+                    ):
+                        seed_engine, seed_stealth = champion.engine, champion.stealth
+                        LOGGER.info(
+                            "Crawl seeding shared %s browser from %s champion (stealth=%s)",
+                            champion.engine or "playwright",
+                            start_domain,
+                            champion.stealth,
+                        )
+
                 # Create and manage own browser lifecycle
                 async with BrowserManager(
                     headless=headless,
                     locale_config=locale_config,
-                    stealth=stealth,
+                    stealth=seed_stealth,
                     proxy=proxy,
-                    engine=engine,
+                    engine=seed_engine,
                 ) as browser:
                     self._browser = browser
                     self._map_service = MapService(

--- a/src/supacrawl/services/crawl.py
+++ b/src/supacrawl/services/crawl.py
@@ -248,20 +248,28 @@ class CrawlService:
                 # explore. A user-pinned engine/stealth still wins over memory.
                 seed_engine, seed_stealth = engine, stealth
                 if self._strategy_store is not None and engine is None and not stealth:
-                    from supacrawl.services.scrape import _engine_available
+                    from supacrawl.services.scrape import _engine_available, _resolve_engine_stealth
                     from supacrawl.services.strategy_memory import _engine_cost, registrable_domain
 
                     start_domain = registrable_domain(url)
                     champion = self._strategy_store.get(start_domain) if start_domain else None
+                    # Gate on the RESOLVED engine's availability: a patchright
+                    # champion is stored as (None, True), which the raw check would
+                    # wave through as "playwright" and then fail launching the one
+                    # shared browser — aborting the whole crawl instead of
+                    # degrading to the default engine.
+                    resolved_engine = (
+                        _resolve_engine_stealth(champion.engine, champion.stealth)[0] if champion is not None else None
+                    )
                     if (
                         champion is not None
                         and _engine_cost(champion.engine, champion.stealth) > 0
-                        and _engine_available(champion.engine)
+                        and _engine_available(resolved_engine)
                     ):
                         seed_engine, seed_stealth = champion.engine, champion.stealth
                         LOGGER.info(
                             "Crawl seeding shared %s browser from %s champion (stealth=%s)",
-                            champion.engine or "playwright",
+                            resolved_engine,
                             start_domain,
                             champion.stealth,
                         )

--- a/src/supacrawl/services/scrape.py
+++ b/src/supacrawl/services/scrape.py
@@ -307,6 +307,30 @@ def _engine_available(engine: str | None) -> bool:
     return False
 
 
+def _resolve_engine_stealth(engine: str | None, stealth: bool) -> tuple[str, bool]:
+    """Resolve a (engine, stealth) request to what a BrowserManager will run.
+
+    Mirrors ``BrowserManager.__init__`` exactly: an explicit engine wins; else
+    ``stealth`` selects patchright; else playwright. ``stealth`` is then a pure
+    function of the resolved engine (True for patchright/camoufox).
+
+    This matters because strategy memory stores a patchright champion as
+    ``(None, True)`` and a camoufox champion as ``("camoufox", False)`` — neither
+    of which equals the ``(engine, stealth)`` the resulting browser reports
+    (``("patchright", True)`` / ``("camoufox", True)``). Comparing a raw seed
+    against a live browser's resolved attributes therefore always mismatches,
+    which would rebuild a temporary browser on every page (#139). Resolve both
+    sides into the same space before comparing.
+    """
+    if engine is not None:
+        resolved = engine
+    elif stealth:
+        resolved = "patchright"
+    else:
+        resolved = "playwright"
+    return resolved, resolved in ("patchright", "camoufox")
+
+
 def _stealth_hint(*, bot_suspected: bool = False) -> str:
     """Return a hint about stealth mode, gated on whether a bot challenge was detected.
 
@@ -987,11 +1011,14 @@ class ScrapeService:
             # A champion learned on a machine that had the engine, replayed where
             # that engine is no longer installed, would hard-fail every hit to the
             # domain (#143). Drop a stale seed so the request degrades to the
-            # default engine instead of cascade-failing on the missing one.
-            if seed is not None and not _engine_available(seed.engine):
+            # default engine instead of cascade-failing on the missing one. Check
+            # the RESOLVED engine: a patchright champion is stored as (None, True),
+            # which _engine_available would wave through as "playwright".
+            if seed is not None and not _engine_available(_resolve_engine_stealth(seed.engine, seed.stealth)[0]):
                 LOGGER.debug(
-                    "Champion engine %r for %s is not installed; ignoring stale strategy seed",
+                    "Champion engine %r (stealth=%s) for %s is not installed; ignoring stale strategy seed",
                     seed.engine,
+                    seed.stealth,
                     memory_domain,
                 )
                 seed = None
@@ -1124,12 +1151,16 @@ class ScrapeService:
             )
             # A learned seed (#130) may want a different engine/stealth than a
             # shared browser; build a temporary one so the champion strategy is
-            # honoured without mutating the shared browser.
+            # honoured without mutating the shared browser. Compare in RESOLVED
+            # space: browser.engine/stealth are post-resolution, so the raw seed
+            # must be resolved too, else a camoufox/patchright champion that the
+            # shared browser already IS would spuriously rebuild every page (#139).
+            seed_resolved_engine, seed_resolved_stealth = _resolve_engine_stealth(attempt_engine, attempt_stealth)
             needs_seed_override = (
                 seed is not None
                 and not owns_browser
                 and browser is not None
-                and (attempt_engine != browser.engine or attempt_stealth != browser.stealth)
+                and (seed_resolved_engine != browser.engine or seed_resolved_stealth != browser.stealth)
             )
 
             if owns_browser or needs_engine_override or needs_proxy_override or needs_seed_override:
@@ -1564,7 +1595,9 @@ class ScrapeService:
         # CAPTCHA is what stopped us (rather than a bare exhausted ladder), record
         # that we chose not to continue and how to override it, so a caller can
         # tell "we deliberately stopped on a CAPTCHA" from "the site was empty".
-        if escalate and captcha_wall and not captcha_escalatable and result.quality is not None:
+        # Only at level 0: a CAPTCHA reached after an earlier rung escalated has
+        # run more than one attempt, so "stopped after one attempt" would be false.
+        if escalate and level == 0 and captcha_wall and not captcha_escalatable and result.quality is not None:
             result.quality.reasons.append(
                 "fail-fast: stopped after one attempt — a stronger engine does not solve a CAPTCHA "
                 "(set SUPACRAWL_CAPTCHA_FAIL_FAST=0 to walk the full ladder, or enable solve_captcha)"

--- a/src/supacrawl/services/scrape.py
+++ b/src/supacrawl/services/scrape.py
@@ -21,6 +21,7 @@ CAPTCHA Solving (optional, requires third-party service):
 
 import base64
 import logging
+import os
 import re
 import time
 from collections.abc import Awaitable, Callable, Sequence
@@ -103,14 +104,39 @@ _LOW_DENSITY_WORDS_PER_KB = 1.0
 # Verdicts where a stronger fetch (stealth engine, longer hydration wait) could
 # plausibly recover real content. A genuine 404 (ERROR_STATUS), a paywall, or a
 # merely-short page are NOT here: escalating them only burns latency.
+#
+# CAPTCHA is deliberately absent (#153): a bare third-party CAPTCHA wall
+# (reCAPTCHA/hCaptcha/standalone Turnstile) is a terminal condition for the
+# engine ladder — a stronger stealth engine does not solve a CAPTCHA, so the
+# three further escalations are pure wasted wall-clock. Fail fast on it and hand
+# the caller the CAPTCHA suggestion (enable solve_captcha, or fetch elsewhere)
+# after a single attempt. A CAPTCHA widget wrapped in a CDN "managed challenge"
+# interstitial (Cloudflare "just a moment") is a stealth engine's job and is
+# classified BOT_CHALLENGE instead (see quality._classify), so it keeps
+# escalating. SUPACRAWL_CAPTCHA_FAIL_FAST=0 restores the walk-the-whole-ladder
+# behaviour (see _captcha_fail_fast).
 _ESCALATABLE_VERDICTS: frozenset[QualityVerdict] = frozenset(
     {
         QualityVerdict.BOT_CHALLENGE,
-        QualityVerdict.CAPTCHA,
         QualityVerdict.JS_SHELL,
         QualityVerdict.EMPTY,
     }
 )
+
+
+def _captcha_fail_fast() -> bool:
+    """Whether a genuine CAPTCHA verdict should stop the ladder after one attempt.
+
+    Default True (#153): escalating a CAPTCHA wall through the stealth/engine
+    ladder wastes three doomed attempts because no stronger engine solves a
+    CAPTCHA. Set ``SUPACRAWL_CAPTCHA_FAIL_FAST=0`` (or ``false``/``no``) to keep
+    CAPTCHA escalatable — the override that keeps this heuristic falsifiable: a
+    caller who believes a CAPTCHA-classified page would in fact yield to a
+    stronger engine can turn the short-circuit off and see the full ladder run.
+    """
+    return os.environ.get("SUPACRAWL_CAPTCHA_FAIL_FAST", "1").strip().lower() not in ("0", "false", "no")
+
+
 # Maximum number of *extra* attempts beyond the first (the escalation budget).
 # The default ladder is playwright → patchright → camoufox → camoufox+HTTP/1.1,
 # so three escalations cover the full ladder.
@@ -1521,14 +1547,28 @@ class ScrapeService:
 
         has_response = result.data is not None
         verdict = result.quality.verdict if result.quality else None
+        # A CAPTCHA wall fails fast (#153): a stronger engine will not solve a
+        # CAPTCHA, so the ladder stops after one attempt unless the operator has
+        # explicitly opted back into walking it (SUPACRAWL_CAPTCHA_FAIL_FAST=0).
+        captcha_wall = verdict == QualityVerdict.CAPTCHA
+        captcha_escalatable = captcha_wall and not _captcha_fail_fast()
         # A thin result on a known site-builder (Wix/Squarespace/Framer/Foleon) is
         # escalatable even though THIN is not in the generic set: the platform has
         # a tuned engine that reliably renders it, where the generic ladder would
         # not fire. `platform` is only set on a thin browser result.
+        escalatable_verdict = verdict in _ESCALATABLE_VERDICTS or captcha_escalatable
         wants_escalation = http2_error or (
-            has_response
-            and ((verdict in _ESCALATABLE_VERDICTS) or platform is not None or (expect is not None and not expect_met))
+            has_response and (escalatable_verdict or platform is not None or (expect is not None and not expect_met))
         )
+        # Make the fail-fast an audible decision, not a silent skip: when a
+        # CAPTCHA is what stopped us (rather than a bare exhausted ladder), record
+        # that we chose not to continue and how to override it, so a caller can
+        # tell "we deliberately stopped on a CAPTCHA" from "the site was empty".
+        if escalate and captcha_wall and not captcha_escalatable and result.quality is not None:
+            result.quality.reasons.append(
+                "fail-fast: stopped after one attempt — a stronger engine does not solve a CAPTCHA "
+                "(set SUPACRAWL_CAPTCHA_FAIL_FAST=0 to walk the full ladder, or enable solve_captcha)"
+            )
         if not escalate or not wants_escalation or level >= _MAX_ESCALATIONS:
             return result
 

--- a/tests/test_escalation.py
+++ b/tests/test_escalation.py
@@ -20,6 +20,12 @@ pytestmark = pytest.mark.asyncio
 
 _BLOCKED_HTML = "<html><body><h1>Access Denied</h1><p>You have been blocked.</p></body></html>"
 _GOOD_HTML = "<html><body><main><p>" + " ".join(f"word{i}" for i in range(200)) + "</p></main></body></html>"
+# A bare third-party CAPTCHA wall: a reCAPTCHA widget, no CDN interstitial text,
+# no usable content. A stronger engine cannot solve it (#153).
+_CAPTCHA_HTML = '<html><body><div class="g-recaptcha" data-sitekey="abc"></div></body></html>'
+# A CAPTCHA widget wrapped in a Cloudflare managed-challenge interstitial: a
+# stealth engine's job, so this must keep escalating.
+_CF_INTERSTITIAL_HTML = '<html><body><h1>Just a moment...</h1><div class="cf-turnstile"></div></body></html>'
 
 
 def _meta() -> PageMetadata:
@@ -101,6 +107,60 @@ async def test_escalation_budget_bounds_attempts(monkeypatch: pytest.MonkeyPatch
     # playwright -> patchright -> camoufox -> camoufox+HTTP/1.1 == 4 attempts, no more.
     assert result.quality.attempts == 4
     assert len(created) == 4
+
+
+async def test_captcha_wall_fails_fast_after_one_attempt(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A bare CAPTCHA wall is terminal for the engine ladder (#153): stop after a
+    # single attempt rather than burning three doomed escalations, and hand the
+    # caller the CAPTCHA suggestion immediately.
+    monkeypatch.delenv("SUPACRAWL_CAPTCHA_FAIL_FAST", raising=False)
+    created = _patch_ladder(monkeypatch, lambda engine, stealth: (_CAPTCHA_HTML, 200))
+    result = await ScrapeService().scrape("https://x.example", formats=["markdown"], http_first=False)
+
+    assert result.success is False
+    assert result.quality is not None
+    assert result.quality.verdict == QualityVerdict.CAPTCHA
+    assert result.quality.attempts == 1  # was 4 before fail-fast
+    assert result.quality.escalated is False
+    assert len(created) == 1  # only the first attempt ran
+    # The suggestion the escalation used to arrive at only after four attempts is
+    # present on the very first result.
+    assert result.quality.suggestion is not None and "captcha" in result.quality.suggestion.lower()
+    # The fail-fast is an audible decision, not a silent skip.
+    assert any("fail-fast" in r for r in result.quality.reasons)
+
+
+async def test_captcha_fail_fast_override_walks_the_ladder(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Falsifiability: SUPACRAWL_CAPTCHA_FAIL_FAST=0 restores the full ladder walk,
+    # so a caller who disagrees with the short-circuit can see it run.
+    monkeypatch.setenv("SUPACRAWL_CAPTCHA_FAIL_FAST", "0")
+    created = _patch_ladder(monkeypatch, lambda engine, stealth: (_CAPTCHA_HTML, 200))
+    result = await ScrapeService().scrape("https://x.example", formats=["markdown"], http_first=False)
+
+    assert result.quality is not None
+    assert result.quality.verdict == QualityVerdict.CAPTCHA
+    assert result.quality.attempts == 4  # ladder walked to exhaustion, as before
+    assert len(created) == 4
+
+
+async def test_cloudflare_interstitial_with_captcha_still_escalates(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A CAPTCHA widget inside a Cloudflare "just a moment" interstitial is a
+    # stealth engine's job — it must NOT be misread as a hard CAPTCHA wall and
+    # fail fast. It classifies BOT_CHALLENGE and keeps escalating (#153 guard).
+    monkeypatch.delenv("SUPACRAWL_CAPTCHA_FAIL_FAST", raising=False)
+
+    def respond(engine: str | None, stealth: bool) -> tuple[str, int]:
+        if stealth or engine == "camoufox":
+            return _GOOD_HTML, 200
+        return _CF_INTERSTITIAL_HTML, 200
+
+    created = _patch_ladder(monkeypatch, respond)
+    result = await ScrapeService().scrape("https://x.example", formats=["markdown"], http_first=False)
+
+    assert result.success is True
+    assert result.quality is not None and result.quality.verdict == QualityVerdict.OK
+    assert result.quality.escalated is True
+    assert len(created) >= 2  # the interstitial escalated to a stealth engine
 
 
 async def test_escalate_false_takes_a_single_attempt(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_escalation.py
+++ b/tests/test_escalation.py
@@ -286,6 +286,102 @@ async def test_http_first_escalatable_verdict_falls_through_to_browser(monkeypat
     assert len(created) >= 1  # the browser path actually ran
 
 
+def _patch_faithful_browser(monkeypatch: pytest.MonkeyPatch) -> list:
+    """Patch BrowserManager with a fake that resolves engine/stealth EXACTLY like
+    the real one (engine wins; else stealth→patchright; stealth = patchright/
+    camoufox). Records every construction so per-page temporary browsers can be
+    counted. The real BrowserManager's resolution is the crux of #139: a fake that
+    stores the raw kwargs would hide the very bug this exercises.
+    """
+    monkeypatch.setattr("supacrawl.services.scrape._is_patchright_available", lambda: True)
+    monkeypatch.setattr("supacrawl.services.scrape._is_camoufox_available", lambda: True)
+    created: list = []
+
+    class FaithfulBrowser:
+        def __init__(self, **kwargs: object) -> None:
+            engine = kwargs.get("engine")
+            stealth = bool(kwargs.get("stealth", False))
+            self.engine = engine if engine is not None else ("patchright" if stealth else "playwright")
+            self.stealth = self.engine in ("patchright", "camoufox")
+            self.proxy = kwargs.get("proxy")
+            created.append(self)
+
+        async def __aenter__(self) -> "FaithfulBrowser":
+            return self
+
+        async def __aexit__(self, *_: object) -> bool:
+            return False
+
+        async def fetch_page(self, url: str, **_: object) -> PageContent:
+            return PageContent(url=url, html=_GOOD_HTML, title="T", status_code=200)
+
+        async def extract_metadata(self, _html: str) -> PageMetadata:
+            return _meta()
+
+    monkeypatch.setattr("supacrawl.services.scrape.BrowserManager", FaithfulBrowser)
+    return created
+
+
+async def test_shared_champion_browser_needs_no_per_page_override(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    # #139 crux: when the crawl's shared browser already IS the domain's champion
+    # engine, a same-domain page must reuse it — NOT build a temporary browser.
+    # This exercises the real needs_seed_override comparison against a faithfully
+    # resolved browser (camoufox resolves stealth=True), the exact path the
+    # earlier ScrapeService-mocking wiring tests never touched.
+    from supacrawl.services.scrape import ScrapeService
+    from supacrawl.services.strategy_memory import StrategyStore
+
+    store = StrategyStore(strategy_dir=tmp_path, explore_rate=0.0)
+    assert await _record_camoufox_champion(store, "hard.example")  # sanity
+
+    created = _patch_faithful_browser(monkeypatch)
+    from supacrawl.services.scrape import BrowserManager  # the patched FaithfulBrowser
+
+    shared_browser = BrowserManager(engine="camoufox", stealth=False)  # crawl's shared browser
+    created.clear()  # count only per-page constructions
+
+    service = ScrapeService(browser=shared_browser, strategy_store=store)
+    result = await service.scrape("https://hard.example/page", formats=["markdown"], http_first=False)
+
+    assert result.success is True
+    assert len(created) == 0, "a per-page temporary browser was built despite the shared browser matching the champion"
+
+
+async def test_shared_weaker_browser_does_build_per_page_override(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    # The contrast: a shared playwright browser with a camoufox champion still
+    # builds a per-page temporary camoufox (the pre-#139 waste), proving the test
+    # above is measuring something real, not a resolution that never overrides.
+    from supacrawl.services.scrape import ScrapeService
+    from supacrawl.services.strategy_memory import StrategyStore
+
+    store = StrategyStore(strategy_dir=tmp_path, explore_rate=0.0)
+    await _record_camoufox_champion(store, "hard.example")
+
+    created = _patch_faithful_browser(monkeypatch)
+    from supacrawl.services.scrape import BrowserManager
+
+    shared_browser = BrowserManager(engine="playwright")  # weaker than the champion
+    created.clear()
+
+    service = ScrapeService(browser=shared_browser, strategy_store=store)
+    result = await service.scrape("https://hard.example/page", formats=["markdown"], http_first=False)
+
+    assert result.success is True
+    assert len(created) == 1 and created[0].engine == "camoufox"
+
+
+async def _record_camoufox_champion(store, domain: str) -> bool:
+    from supacrawl.models import QualityAssessment, QualityVerdict, ScrapeData, ScrapeMetadata, ScrapeResult
+
+    good = ScrapeResult(
+        success=True,
+        quality=QualityAssessment(verdict=QualityVerdict.OK, score=90),
+        data=ScrapeData(markdown="ok", metadata=ScrapeMetadata(source_url=f"https://{domain}/")),
+    )
+    store.record(domain, engine="camoufox", stealth=False, wait_for=5000, only_main_content=True, result=good)
+    return store.get(domain) is not None
+
+
 async def test_fetch_exception_yields_clean_failure_not_crash() -> None:
     # A mid-fetch exception must become success=False with a hint, never a crash.
     browser = MagicMock()

--- a/tests/test_strategy_memory_wiring.py
+++ b/tests/test_strategy_memory_wiring.py
@@ -19,6 +19,8 @@ import pytest
 from supacrawl.models import (
     MapEvent,
     MapResult,
+    QualityAssessment,
+    QualityVerdict,
     ScrapeData,
     ScrapeMetadata,
     ScrapeResult,
@@ -30,8 +32,11 @@ from supacrawl.telemetry import MetricsSink
 
 # Opaque sentinels: the tests assert these exact objects are threaded through to
 # ScrapeService, not that they behave as a real store/sink (ScrapeService is
-# mocked). cast keeps the type checker honest without a real instance.
-_STORE = cast(StrategyStore, object())
+# mocked). The store must answer ``get`` (the crawl consults the start domain's
+# champion at launch, #139); a None champion means "no seeding", so the wiring
+# tests exercise the default-browser path. cast keeps the type checker honest.
+_STORE = MagicMock(spec=StrategyStore)
+_STORE.get.return_value = None
 _TELEMETRY = cast(MetricsSink, object())
 
 
@@ -93,6 +98,102 @@ async def test_crawl_without_store_passes_none() -> None:
         kwargs = mock_scrape_cls.call_args.kwargs
         assert kwargs["strategy_store"] is None
         assert kwargs["telemetry"] is None
+
+
+def _camoufox_champion_store(tmp_path, domain: str) -> StrategyStore:
+    """A real store whose champion for ``domain`` is camoufox (exploration off)."""
+    store = StrategyStore(strategy_dir=tmp_path, explore_rate=0.0)
+    good = ScrapeResult(
+        success=True,
+        quality=QualityAssessment(verdict=QualityVerdict.OK, score=90),
+        data=ScrapeData(markdown="ok", metadata=ScrapeMetadata(source_url=f"https://{domain}/")),
+    )
+    store.record(domain, engine="camoufox", stealth=False, wait_for=5000, only_main_content=True, result=good)
+    return store
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_crawl_seeds_shared_browser_from_champion(tmp_path) -> None:
+    """A hard-site (camoufox champion) crawl builds ONE shared camoufox browser (#139)."""
+
+    async def fake_map(**_: object) -> AsyncGenerator[MapEvent, None]:
+        yield MapEvent(type="complete", discovered=0, result=MapResult(success=True, links=[]))
+
+    store = _camoufox_champion_store(tmp_path, "hard.example")
+
+    with (
+        patch("supacrawl.services.crawl.BrowserManager") as mock_bm,
+        patch("supacrawl.services.crawl.MapService") as mock_map_cls,
+        patch("supacrawl.services.crawl.ScrapeService"),
+        patch("supacrawl.services.scrape._engine_available", return_value=True),
+    ):
+        _async_cm(mock_bm.return_value)
+        mock_map_cls.return_value.map = fake_map
+
+        service = CrawlService(strategy_store=store)
+        async for _ in service.crawl(url="https://hard.example/start", limit=10, formats=["markdown"]):
+            pass
+
+        # The shared browser is constructed once, with the champion engine, so no
+        # per-page temporary camoufox launches are needed for same-domain pages.
+        mock_bm.assert_called_once()
+        assert mock_bm.call_args.kwargs["engine"] == "camoufox"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_crawl_user_pinned_engine_bypasses_champion_seed(tmp_path) -> None:
+    """A user-pinned engine wins over a camoufox champion (#139)."""
+
+    async def fake_map(**_: object) -> AsyncGenerator[MapEvent, None]:
+        yield MapEvent(type="complete", discovered=0, result=MapResult(success=True, links=[]))
+
+    store = _camoufox_champion_store(tmp_path, "hard.example")
+
+    with (
+        patch("supacrawl.services.crawl.BrowserManager") as mock_bm,
+        patch("supacrawl.services.crawl.MapService") as mock_map_cls,
+        patch("supacrawl.services.crawl.ScrapeService"),
+        patch("supacrawl.services.scrape._engine_available", return_value=True),
+    ):
+        _async_cm(mock_bm.return_value)
+        mock_map_cls.return_value.map = fake_map
+
+        service = CrawlService(strategy_store=store)
+        async for _ in service.crawl(
+            url="https://hard.example/start", limit=10, formats=["markdown"], engine="playwright"
+        ):
+            pass
+
+        mock_bm.assert_called_once()
+        assert mock_bm.call_args.kwargs["engine"] == "playwright"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_crawl_soft_site_unchanged_no_champion(tmp_path) -> None:
+    """A crawl with no champion for the start domain builds the default browser (#139)."""
+
+    async def fake_map(**_: object) -> AsyncGenerator[MapEvent, None]:
+        yield MapEvent(type="complete", discovered=0, result=MapResult(success=True, links=[]))
+
+    store = StrategyStore(strategy_dir=tmp_path, explore_rate=0.0)  # empty: no champion
+
+    with (
+        patch("supacrawl.services.crawl.BrowserManager") as mock_bm,
+        patch("supacrawl.services.crawl.MapService") as mock_map_cls,
+        patch("supacrawl.services.crawl.ScrapeService"),
+    ):
+        _async_cm(mock_bm.return_value)
+        mock_map_cls.return_value.map = fake_map
+
+        service = CrawlService(strategy_store=store)
+        async for _ in service.crawl(url="https://soft.example/start", limit=10, formats=["markdown"]):
+            pass
+
+        mock_bm.assert_called_once()
+        assert mock_bm.call_args.kwargs["engine"] is None  # default, no per-page override needed
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Behavioural half of the razor-sharp-tools goal that PR #167 hardened at the engine layer: **decide early, spend once, be honest about what happened.** Stacked on `fix/stealth-engine-resilience` (#167) for a clean diff; retarget to `main` once #167 merges.

## What lands

### #153 — Fail fast on a CAPTCHA wall (the headline)
A bare third-party CAPTCHA (reCAPTCHA/hCaptcha/standalone Turnstile) is terminal for the engine ladder — a stronger stealth engine does not solve a CAPTCHA. It was walking all four rungs (~30s of pure retry noise, compounding on twice-daily crawls). Now it stops after one attempt.
- `CAPTCHA` dropped from `_ESCALATABLE_VERDICTS`; gated by `_captcha_fail_fast()` (env `SUPACRAWL_CAPTCHA_FAIL_FAST`, default on).
- **Honest, not a lie:** verdict stays `captcha` (distinct from `empty`) — a scraper-side decision to stop, never "the site returned nothing". The fail-fast is recorded in `quality.reasons` with how to override it, so a caller can tell "we chose not to continue" from "nothing there".
- **Falsifiable/overridable:** `SUPACRAWL_CAPTCHA_FAIL_FAST=0` restores the full-ladder walk.
- **No Cloudflare regression:** a CAPTCHA inside a CDN managed-challenge interstitial (`challenge_detected` — "just a moment"/Turnstile) classifies `BOT_CHALLENGE` and keeps escalating. Only a bare widget fails fast.
- **Driven (real playwright→patchright→camoufox ladder, local reCAPTCHA fixture): attempts 4 → 1, wall-clock 7.8s → 0.8s.**

### #139 — Crawl seeds its shared browser from the start domain's champion
A hard-site (camoufox) crawl was launching a fresh stealth browser *per page* instead of sharing one. Now the crawl consults the start domain's champion once (exploration-free `StrategyStore.get`) and builds the shared browser with it. User-pinned `--engine`/`--stealth` still wins; no champion → unchanged.
- Comparison done in **resolved** engine/stealth space (`_resolve_engine_stealth`), because a camoufox champion is stored as `(camoufox, False)` but a BrowserManager resolves it to `stealth=True` — the review caught that a raw comparison made the seed a per-page no-op.
- **Driven (faithful resolution): per-page temporary browsers 2 → 0** on a two-page same-domain crawl.

### #150 — NTFY_TOKEN provisioned
Repo secret set out-of-band from the household broker's `ntfy-api` credential (value never transited a transcript). Stale "unset for this repo" CI comment corrected.

## Left apart (with reasons)
- **#142** (disclosure-gated pages into the browser): the issue itself states there is *no cheap static signal*; every proposed direction is a new per-domain richness-probe / first-encounter-comparison learning mechanism — exactly the strategy-engine machinery this lane was asked not to build. priority:low. Belongs apart.

## Review
One fresh-context adversarial review pass; its critical finding (the #139 no-op above) and mediums are fixed in commit `45d1f3c`. Gates green: `ruff`, `mypy`, `pytest -m "not e2e"` (1514 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)